### PR TITLE
Home dashboard

### DIFF
--- a/TinniTrack/Domain/Models/Study.swift
+++ b/TinniTrack/Domain/Models/Study.swift
@@ -1,0 +1,35 @@
+//
+//  Study.swift
+//  TinniTrack
+//
+
+import Foundation
+
+struct Study: Identifiable, Equatable {
+    let id: UUID
+    let slug: String
+    let title: String
+    let description: String
+    let status: StudyRecruitmentStatus
+    let createdAt: Date?
+}
+
+enum StudyRecruitmentStatus: Equatable {
+    case recruiting
+    case recruitingPaused
+    case closed
+    case unknown(String)
+
+    init(rawValue: String) {
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "recruiting":
+            self = .recruiting
+        case "recruiting paused":
+            self = .recruitingPaused
+        case "closed":
+            self = .closed
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+}

--- a/TinniTrack/Domain/Models/StudyEnrollment.swift
+++ b/TinniTrack/Domain/Models/StudyEnrollment.swift
@@ -1,0 +1,38 @@
+//
+//  StudyEnrollment.swift
+//  TinniTrack
+//
+
+import Foundation
+
+struct StudyEnrollment: Identifiable, Equatable {
+    let id: UUID
+    let userID: UUID
+    let studyID: UUID
+    let status: StudyEnrollmentStatus
+    let enrolledAt: Date?
+    let createdAt: Date?
+}
+
+enum StudyEnrollmentStatus: Equatable {
+    case enrolled
+    case withdrawn
+    case completed
+    case screenFailed
+    case unknown(String)
+
+    init(rawValue: String) {
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "enrolled":
+            self = .enrolled
+        case "withdrawn":
+            self = .withdrawn
+        case "completed":
+            self = .completed
+        case "screen_failed":
+            self = .screenFailed
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+}

--- a/TinniTrack/Features/Dashboard/ViewModels/HomeDashboardViewModel.swift
+++ b/TinniTrack/Features/Dashboard/ViewModels/HomeDashboardViewModel.swift
@@ -49,6 +49,7 @@ final class HomeDashboardViewModel: ObservableObject {
 
             state = studies.isEmpty ? .empty : .loaded
         } catch {
+            print("HomeDashboardViewModel.refresh() failed with error:", error)
             studies = []
             state = .empty
         }

--- a/TinniTrack/Features/Dashboard/ViewModels/HomeDashboardViewModel.swift
+++ b/TinniTrack/Features/Dashboard/ViewModels/HomeDashboardViewModel.swift
@@ -1,0 +1,96 @@
+//
+//  HomeDashboardViewModel.swift
+//  TinniTrack
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class HomeDashboardViewModel: ObservableObject {
+    @Published private(set) var state: State = .loading
+    @Published private(set) var studies: [DashboardStudyCard] = []
+    @Published private(set) var enrollingStudyID: UUID?
+
+    enum State: Equatable {
+        case loading
+        case loaded
+        case empty
+    }
+
+    private let studyService: StudyServiceProtocol
+    private var hasLoadedOnce = false
+
+    init(studyService: StudyServiceProtocol) {
+        self.studyService = studyService
+    }
+
+    func loadIfNeeded() async {
+        guard !hasLoadedOnce else { return }
+        await refresh()
+    }
+
+    func refresh() async {
+        state = .loading
+        do {
+            async let studiesTask = studyService.fetchStudies()
+            async let enrollmentsTask = studyService.fetchMyEnrollments()
+
+            let studyRows = try await studiesTask
+            let enrollmentRows = try await enrollmentsTask
+            let enrollmentByStudyID = Dictionary(
+                enrollmentRows.map { ($0.studyID, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+
+            studies = studyRows.map {
+                DashboardStudyCard(study: $0, enrollment: enrollmentByStudyID[$0.id])
+            }
+
+            state = studies.isEmpty ? .empty : .loaded
+        } catch {
+            studies = []
+            state = .empty
+        }
+        hasLoadedOnce = true
+    }
+
+    func enroll(studyID: UUID) async throws {
+        enrollingStudyID = studyID
+        defer { enrollingStudyID = nil }
+        try await studyService.enroll(studyID: studyID)
+        await refresh()
+    }
+}
+
+struct DashboardStudyCard: Identifiable, Equatable {
+    let study: Study
+    let enrollment: StudyEnrollment?
+
+    var id: UUID { study.id }
+
+    var isEnrolledActive: Bool {
+        enrollment?.status == .enrolled
+    }
+
+    var badgeText: String {
+        if isEnrolledActive {
+            return "ACTIVE"
+        }
+
+        switch study.status {
+        case .recruiting:
+            return "RECRUITING"
+        case .recruitingPaused:
+            return "PAUSED"
+        case .closed:
+            return "CLOSED"
+        case .unknown(let raw):
+            return raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        }
+    }
+
+    var callToActionText: String {
+        isEnrolledActive ? "Go to Tasks" : "View Details"
+    }
+}

--- a/TinniTrack/Features/Dashboard/Views/HomeView.swift
+++ b/TinniTrack/Features/Dashboard/Views/HomeView.swift
@@ -100,7 +100,7 @@ private struct DashboardTabView: View {
             }
         case .empty:
             ContentUnavailableView {
-                Label("No Studies Available at this time.", systemImage: "magnifyingglass")
+                Label("No studies available at this time.", systemImage: "magnifyingglass")
             } description: {
                 Text("Please check back later.")
             }

--- a/TinniTrack/Features/Dashboard/Views/HomeView.swift
+++ b/TinniTrack/Features/Dashboard/Views/HomeView.swift
@@ -1,158 +1,453 @@
 //
 //  HomeView.swift
-//  Tinnitus Capstone
-//
-//  Created by Anika Patel on 11/10/25.
+//  TinniTrack
 //
 
 import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject private var sessionStore: SessionStore
+    @StateObject private var dashboardViewModel: HomeDashboardViewModel
+    @State private var selectedTab: Tab = .dashboard
+
+    init(studyService: StudyServiceProtocol = SupabaseStudyService()) {
+        _dashboardViewModel = StateObject(wrappedValue: HomeDashboardViewModel(studyService: studyService))
+    }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Header with menu and title
-            HStack {
-                Button(action: {
-                    Task {
-                        await sessionStore.signOut()
-                    }
-                }) {
-                    Image(systemName: "line.3.horizontal")
-                        .font(.system(size: 24))
-                        .foregroundColor(.black)
-                }
-
-                Spacer()
-
-                Text("HOME")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.black)
-
-                Spacer()
-
-                // Empty space for symmetry
-                Color.clear.frame(width: 24, height: 24)
+        TabView(selection: $selectedTab) {
+            NavigationStack {
+                DashboardTabView(
+                    firstName: displayFirstName,
+                    viewModel: dashboardViewModel
+                )
             }
-            .padding(.horizontal, 16)
-            .frame(height: 56)
-
-            // Search bar
-            HStack(spacing: 12) {
-                Image(systemName: "magnifyingglass")
-                    .frame(width: 24, height: 24)
-                    .foregroundColor(Color(red: 0.51, green: 0.51, blue: 0.51))
-
-                Text("Search")
-                    .font(.system(size: 16))
-                    .foregroundColor(Color(red: 0.51, green: 0.51, blue: 0.51))
-
-                Spacer()
+            .tabItem {
+                Label("Dashboard", systemImage: "list.bullet.clipboard")
             }
-            .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 16))
-            .frame(height: 40)
-            .background(.white)
-            .cornerRadius(8)
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color(red: 0.88, green: 0.88, blue: 0.88), lineWidth: 0.5)
-            )
-            .padding(.horizontal, 16)
-            .padding(.top, 8)
+            .tag(Tab.dashboard)
 
-            // Quick Actions header
-            Text("QUICK ACTIONS")
-                .font(.system(size: 20, weight: .heavy))
-                .foregroundColor(.black)
-                .padding(.top, 32)
-                .padding(.bottom, 16)
-
-            // Quick Actions buttons (2x2 grid)
-            VStack(spacing: 12) {
-                HStack(spacing: 12) {
-                    // FAQs button
-                    Button(action: {
-                        print("FAQs tapped")
-                    }) {
-                        Text("FAQs")
-                            .font(.system(size: 20, weight: .heavy))
-                            .foregroundColor(.black)
-                            .frame(width: 163, height: 98)
-                            .background(.white)
-                            .cornerRadius(30)
-                    }
-
-                    // Settings button
-                    Button(action: {
-                        print("Settings tapped")
-                    }) {
-                        Text("SETTINGS")
-                            .font(.system(size: 20, weight: .heavy))
-                            .foregroundColor(.black)
-                            .frame(width: 164, height: 98)
-                            .background(.white)
-                            .cornerRadius(30)
-                    }
-                }
-
-                HStack(spacing: 12) {
-                    // Patient History button
-                    Button(action: {
-                        print("Patient History tapped")
-                    }) {
-                        Text("PATIENT\nHISTORY")
-                            .font(.system(size: 20, weight: .heavy))
-                            .multilineTextAlignment(.center)
-                            .foregroundColor(.black)
-                            .frame(width: 164, height: 98)
-                            .background(.white)
-                            .cornerRadius(30)
-                    }
-
-                    // Therapy button
-                    Button(action: {
-                        print("Therapy tapped")
-                    }) {
-                        Text("THERAPY")
-                            .font(.system(size: 20, weight: .heavy))
-                            .foregroundColor(.black)
-                            .frame(width: 164, height: 98)
-                            .background(.white)
-                            .cornerRadius(30)
-                    }
-                }
+            NavigationStack {
+                ProfileTabView()
             }
-            .padding(.horizontal, 16)
-
-            Spacer()
-
-            // Loudness Matching button
-            // Loudness Matching button - navigates to LoudnessMatchView
-            NavigationLink(destination: LoudnessMatchView()) {
-                Text("LOUDNESS MATCHING")
-                    .font(.system(size: 24, weight: .heavy))
-                    .foregroundColor(.black)
-                    .frame(width: 356, height: 171)
-                    .background(.white)
-                    .cornerRadius(30)
+            .tabItem {
+                Label("Profile", systemImage: "person.circle")
             }
-            .padding(.bottom, 20)
-
-            // Home indicator (bottom bar)
-            Rectangle()
-                .fill(Color.black)
-                .frame(width: 134, height: 5)
-                .cornerRadius(100)
-                .padding(.bottom, 8)
+            .tag(Tab.profile)
         }
-        .background(Color(red: 0.95, green: 0.95, blue: 0.95))
-        .navigationBarHidden(true)
+    }
+
+    private var displayFirstName: String {
+        let trimmed = sessionStore.profile?.firstName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "Participant" : trimmed
     }
 }
 
-struct HomeView_Previews: PreviewProvider {
-    static var previews: some View {
-        HomeView()
+private enum Tab {
+    case dashboard
+    case profile
+}
+
+private struct DashboardTabView: View {
+    let firstName: String
+    @ObservedObject var viewModel: HomeDashboardViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+
+                Text("CURRENT STUDIES")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .tracking(0.8)
+                    .foregroundStyle(.secondary)
+
+                content
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+        }
+        .background(Color(uiColor: .systemGroupedBackground))
+        .navigationTitle("Dashboard")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.loadIfNeeded()
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Hello, \(firstName)")
+                .font(.system(.largeTitle, weight: .bold))
+                .foregroundStyle(.primary)
+            Text("Welcome to TinniTrack.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .loading:
+            LazyVStack(spacing: 16) {
+                ShimmerStudyCardView()
+                ShimmerStudyCardView()
+            }
+        case .empty:
+            ContentUnavailableView {
+                Label("No Studies Available at this time.", systemImage: "magnifyingglass")
+            } description: {
+                Text("Please check back later.")
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 24)
+        case .loaded:
+            LazyVStack(spacing: 16) {
+                ForEach(viewModel.studies) { studyCard in
+                    NavigationLink {
+                        destination(for: studyCard)
+                    } label: {
+                        StudyCardView(studyCard: studyCard)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func destination(for studyCard: DashboardStudyCard) -> some View {
+        if studyCard.isEnrolledActive {
+            StudyTaskDashboardView(study: studyCard.study)
+        } else {
+            StudyDetailView(studyCard: studyCard) {
+                try await viewModel.enroll(studyID: studyCard.study.id)
+            }
+        }
+    }
+}
+
+private struct StudyCardView: View {
+    let studyCard: DashboardStudyCard
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(studyCard.study.title)
+                    .font(.headline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+
+                Spacer(minLength: 12)
+
+                Text(studyCard.badgeText)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .tracking(0.8)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(studyCard.badgeColor)
+                    .clipShape(Capsule())
+            }
+
+            Text(studyCard.study.description)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+
+            HStack(spacing: 6) {
+                Text(studyCard.callToActionText)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(DashboardColors.brandBlue)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(DashboardColors.brandBlue)
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .padding(18)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+    }
+}
+
+private struct StudyDetailView: View {
+    let studyCard: DashboardStudyCard
+    let onEnroll: () async throws -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var isEnrolling = false
+    @State private var enrollmentErrorMessage: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                detailCard(title: "Description", body: studyCard.study.description)
+                criteriaCard(title: "Inclusion Criteria", items: Self.inclusionCriteria)
+                criteriaCard(title: "Exclusion Criteria", items: Self.exclusionCriteria)
+
+                Button {
+                    Task { await handleEnrollTapped() }
+                } label: {
+                    HStack {
+                        if isEnrolling {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            Text(canEnroll ? "Begin eConsent & Enroll" : "Enrollment Unavailable")
+                                .fontWeight(.semibold)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                }
+                .buttonStyle(.plain)
+                .background(canEnroll ? DashboardColors.brandBlue : Color(uiColor: .systemGray3))
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .disabled(!canEnroll || isEnrolling)
+            }
+            .padding(20)
+        }
+        .background(Color(uiColor: .systemGroupedBackground))
+        .navigationTitle(studyCard.study.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("Unable to Enroll", isPresented: Binding(
+            get: { enrollmentErrorMessage != nil },
+            set: { shouldShow in
+                if !shouldShow {
+                    enrollmentErrorMessage = nil
+                }
+            }
+        )) {
+            Button("OK", role: .cancel) {
+                enrollmentErrorMessage = nil
+            }
+        } message: {
+            Text(enrollmentErrorMessage ?? "")
+        }
+    }
+
+    private var canEnroll: Bool {
+        if case .recruiting = studyCard.study.status {
+            return true
+        }
+        return false
+    }
+
+    private func detailCard(title: String, body: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.headline)
+            Text(body)
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .shadow(color: .black.opacity(0.08), radius: 3, x: 0, y: 1)
+    }
+
+    private func criteriaCard(title: String, items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.headline)
+            ForEach(items, id: \.self) { item in
+                HStack(alignment: .top, spacing: 8) {
+                    Text("•")
+                    Text(item)
+                }
+                .foregroundStyle(.secondary)
+                .font(.subheadline)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .shadow(color: .black.opacity(0.08), radius: 3, x: 0, y: 1)
+    }
+
+    @MainActor
+    private func handleEnrollTapped() async {
+        guard canEnroll else { return }
+        isEnrolling = true
+        defer { isEnrolling = false }
+
+        do {
+            try await onEnroll()
+            dismiss()
+        } catch {
+            enrollmentErrorMessage = error.localizedDescription
+        }
+    }
+
+    private static let inclusionCriteria = [
+        "Adults (18+) with self-reported tinnitus.",
+        "Access to an iPhone and AirPods Pro (2nd generation).",
+        "Able to complete scheduled loudness-matching tasks."
+    ]
+
+    private static let exclusionCriteria = [
+        "Unable to provide informed consent.",
+        "No compatible headphones for calibration workflows.",
+        "Medical conditions that make headphone listening unsafe."
+    ]
+}
+
+private struct StudyTaskDashboardView: View {
+    let study: Study
+
+    var body: some View {
+        List {
+            Section("Future Tasks") {
+                Text("No upcoming tasks yet.")
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Completed Tasks") {
+                Text("No completed tasks yet.")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(study.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct ProfileTabView: View {
+    @EnvironmentObject private var sessionStore: SessionStore
+    @State private var isSigningOut = false
+
+    var body: some View {
+        Form {
+            Section("Profile") {
+                LabeledContent("First Name", value: sessionStore.profile?.firstName ?? "Not set")
+                LabeledContent("Last Name", value: sessionStore.profile?.lastName ?? "Not set")
+            }
+
+            Section("Research") {
+                LabeledContent("Participant ID", value: participantIDText)
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    Task { await signOut() }
+                } label: {
+                    if isSigningOut {
+                        ProgressView()
+                    } else {
+                        Text("Log Out")
+                    }
+                }
+                .disabled(isSigningOut)
+            }
+        }
+        .navigationTitle("Profile")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var participantIDText: String {
+        guard let participantID = sessionStore.profile?.participantID else { return "Unavailable" }
+        return String(participantID)
+    }
+
+    @MainActor
+    private func signOut() async {
+        isSigningOut = true
+        defer { isSigningOut = false }
+        await sessionStore.signOut()
+    }
+}
+
+private struct ShimmerStudyCardView: View {
+    @State private var shimmerOffset: CGFloat = -260
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(Color.white)
+            .frame(height: 170)
+            .overlay {
+                VStack(alignment: .leading, spacing: 14) {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color(uiColor: .systemGray5))
+                        .frame(width: 200, height: 18)
+
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Color(uiColor: .systemGray5))
+                        .frame(height: 12)
+
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Color(uiColor: .systemGray5))
+                        .frame(width: 240, height: 12)
+
+                    Spacer()
+
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Color(uiColor: .systemGray5))
+                        .frame(width: 100, height: 12)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                .padding(18)
+            }
+            .overlay {
+                GeometryReader { geometry in
+                    Rectangle()
+                        .fill(
+                            LinearGradient(
+                                colors: [.clear, .white.opacity(0.7), .clear],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .frame(width: geometry.size.width * 0.7)
+                        .rotationEffect(.degrees(20))
+                        .offset(x: shimmerOffset)
+                }
+                .clipped()
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+            .onAppear {
+                shimmerOffset = -260
+                withAnimation(.linear(duration: 1.1).repeatForever(autoreverses: false)) {
+                    shimmerOffset = 320
+                }
+            }
+    }
+}
+
+private enum DashboardColors {
+    static let brandBlue = Color(red: 0.23, green: 0.43, blue: 0.73)
+}
+
+private extension DashboardStudyCard {
+    var badgeColor: Color {
+        if isEnrolledActive {
+            return DashboardColors.brandBlue
+        }
+        switch study.status {
+        case .recruiting:
+            return Color(uiColor: .systemGreen)
+        case .recruitingPaused:
+            return Color(uiColor: .systemOrange)
+        case .closed:
+            return Color(uiColor: .systemGray)
+        case .unknown:
+            return Color(uiColor: .systemGray2)
+        }
     }
 }

--- a/TinniTrack/Services/Studies/StudyServiceProtocol.swift
+++ b/TinniTrack/Services/Studies/StudyServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  StudyServiceProtocol.swift
+//  TinniTrack
+//
+
+import Foundation
+
+protocol StudyServiceProtocol {
+    func fetchStudies() async throws -> [Study]
+    func fetchMyEnrollments() async throws -> [StudyEnrollment]
+    func enroll(studyID: UUID) async throws
+}

--- a/TinniTrack/Services/Studies/SupabaseStudyService.swift
+++ b/TinniTrack/Services/Studies/SupabaseStudyService.swift
@@ -1,0 +1,202 @@
+//
+//  SupabaseStudyService.swift
+//  TinniTrack
+//
+
+import Foundation
+import Supabase
+
+final class SupabaseStudyService: StudyServiceProtocol {
+    private let client: SupabaseClient
+
+    init(client: SupabaseClient = supabase) {
+        self.client = client
+    }
+
+    func fetchStudies() async throws -> [Study] {
+        let rows: [StudyRow] = try await client
+            .from("studies")
+            .select("id,slug,title,description,status,created_at")
+            .order("created_at", ascending: false)
+            .execute()
+            .value
+
+        return rows.map { $0.toDomain() }
+    }
+
+    func fetchMyEnrollments() async throws -> [StudyEnrollment] {
+        guard let userID = try await currentUserID() else {
+            return []
+        }
+
+        let rows: [StudyEnrollmentRow] = try await client
+            .from("study_enrollments")
+            .select("id,user_id,study_id,status,enrolled_at,created_at")
+            .eq("user_id", value: userID.uuidString)
+            .execute()
+            .value
+
+        return rows.map { $0.toDomain() }
+    }
+
+    func enroll(studyID: UUID) async throws {
+        guard let userID = try await currentUserID() else {
+            throw NSError(
+                domain: "StudyService",
+                code: 401,
+                userInfo: [NSLocalizedDescriptionKey: "No active session."]
+            )
+        }
+
+        let existing: [EnrollmentLookupRow] = try await client
+            .from("study_enrollments")
+            .select("id")
+            .eq("user_id", value: userID.uuidString)
+            .eq("study_id", value: studyID.uuidString)
+            .limit(1)
+            .execute()
+            .value
+
+        if let enrollmentID = existing.first?.id {
+            try await client
+                .from("study_enrollments")
+                .update(EnrollmentStatusPayload(
+                    status: "enrolled",
+                    enrolledAt: Self.iso8601Formatter.string(from: Date())
+                ))
+                .eq("id", value: enrollmentID.uuidString)
+                .execute()
+        } else {
+            try await client
+                .from("study_enrollments")
+                .insert(NewEnrollmentPayload(
+                    userID: userID,
+                    studyID: studyID,
+                    status: "enrolled",
+                    enrolledAt: Self.iso8601Formatter.string(from: Date())
+                ))
+                .execute()
+        }
+    }
+
+    private func currentUserID() async throws -> UUID? {
+        do {
+            let session = try await client.auth.session
+            return session.user.id
+        } catch {
+            return nil
+        }
+    }
+
+    fileprivate static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}
+
+private struct StudyRow: Decodable {
+    let id: UUID
+    let slug: String
+    let title: String
+    let description: String
+    let status: String
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case slug
+        case title
+        case description
+        case status
+        case createdAt = "created_at"
+    }
+
+    func toDomain() -> Study {
+        Study(
+            id: id,
+            slug: slug,
+            title: title,
+            description: description,
+            status: StudyRecruitmentStatus(rawValue: status),
+            createdAt: Self.parseTimestamp(createdAt)
+        )
+    }
+
+    private static func parseTimestamp(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        if let date = SupabaseStudyService.iso8601Formatter.date(from: value) {
+            return date
+        }
+        let fallback = ISO8601DateFormatter()
+        fallback.formatOptions = [.withInternetDateTime]
+        return fallback.date(from: value)
+    }
+}
+
+private struct StudyEnrollmentRow: Decodable {
+    let id: UUID
+    let userID: UUID
+    let studyID: UUID
+    let status: String
+    let enrolledAt: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userID = "user_id"
+        case studyID = "study_id"
+        case status
+        case enrolledAt = "enrolled_at"
+        case createdAt = "created_at"
+    }
+
+    func toDomain() -> StudyEnrollment {
+        StudyEnrollment(
+            id: id,
+            userID: userID,
+            studyID: studyID,
+            status: StudyEnrollmentStatus(rawValue: status),
+            enrolledAt: Self.parseTimestamp(enrolledAt),
+            createdAt: Self.parseTimestamp(createdAt)
+        )
+    }
+
+    private static func parseTimestamp(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        if let date = SupabaseStudyService.iso8601Formatter.date(from: value) {
+            return date
+        }
+        let fallback = ISO8601DateFormatter()
+        fallback.formatOptions = [.withInternetDateTime]
+        return fallback.date(from: value)
+    }
+}
+
+private struct EnrollmentLookupRow: Decodable {
+    let id: UUID
+}
+
+private struct EnrollmentStatusPayload: Encodable {
+    let status: String
+    let enrolledAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case enrolledAt = "enrolled_at"
+    }
+}
+
+private struct NewEnrollmentPayload: Encodable {
+    let userID: UUID
+    let studyID: UUID
+    let status: String
+    let enrolledAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "user_id"
+        case studyID = "study_id"
+        case status
+        case enrolledAt = "enrolled_at"
+    }
+}

--- a/TinniTrack/Shared/App/AppRootView.swift
+++ b/TinniTrack/Shared/App/AppRootView.swift
@@ -9,20 +9,7 @@ struct AppRootView: View {
     @EnvironmentObject private var sessionStore: SessionStore
 
     var body: some View {
-        NavigationStack {
-            switch sessionStore.phase {
-            case .loading:
-                ProgressView("Loading…")
-            case .unauthenticated:
-                LoginView()
-            case .awaitingEmailVerification:
-                EmailVerificationPendingView()
-            case .authenticatedNeedsOnboarding:
-                CompleteOnboardingView()
-            case .authenticatedReady:
-                HomeView()
-            }
-        }
+        rootContent
         .alert("Error", isPresented: Binding(
             get: { sessionStore.errorMessage != nil },
             set: { _ in sessionStore.dismissError() }
@@ -42,6 +29,29 @@ struct AppRootView: View {
         .fullScreenCover(isPresented: $sessionStore.shouldPresentPasswordReset) {
             ResetPasswordView()
                 .environmentObject(sessionStore)
+        }
+    }
+
+    @ViewBuilder
+    private var rootContent: some View {
+        switch sessionStore.phase {
+        case .authenticatedReady:
+            HomeView()
+        case .loading, .unauthenticated, .awaitingEmailVerification, .authenticatedNeedsOnboarding:
+            NavigationStack {
+                switch sessionStore.phase {
+                case .loading:
+                    ProgressView("Loading…")
+                case .unauthenticated:
+                    LoginView()
+                case .awaitingEmailVerification:
+                    EmailVerificationPendingView()
+                case .authenticatedNeedsOnboarding:
+                    CompleteOnboardingView()
+                case .authenticatedReady:
+                    EmptyView()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces an implementation for handling user study participation in the app, including domain models, a service protocol and Supabase-backed implementation, and integration into the dashboard view model. The changes enable fetching studies and enrollments, enrolling in studies, and displaying study status in the UI. Additionally, the app root view structure is refactored for improved navigation handling.

**Study Participation Domain and Service Implementation:**

- Added new domain models: `Study`, `StudyRecruitmentStatus`, `StudyEnrollment`, and `StudyEnrollmentStatus` to represent studies and user participation states. [[1]](diffhunk://#diff-9c4708f626a16de9f3391bdc239b1a84fc085d7d38f7c4f4e12aa0b43fa15e8cR1-R35) [[2]](diffhunk://#diff-edd09a1d0bf6bd3057596835754ac228ece2c7441cc9568078d219df2d65d8a5R1-R38)
- Introduced `StudyServiceProtocol` defining async methods for fetching studies, enrollments, and enrolling in a study.
- Implemented `SupabaseStudyService` conforming to `StudyServiceProtocol`, handling network operations for studies and enrollments, mapping Supabase rows to domain models, and managing enrollment logic.

**Dashboard Integration:**

- Created `HomeDashboardViewModel` to fetch studies and enrollments, manage loading state, and provide study cards for UI display, including enrollment actions and status badges.

**App Navigation Refactor:**

- Refactored `AppRootView` to extract navigation logic into a `rootContent` computed property, ensuring `HomeView` is displayed directly when authenticated, and other states are wrapped in a `NavigationStack`. [[1]](diffhunk://#diff-8c1d8de95e0939e5b120c6ee4f5347dce6885edf57c2ae6b6f77028265319088L12-R12) [[2]](diffhunk://#diff-8c1d8de95e0939e5b120c6ee4f5347dce6885edf57c2ae6b6f77028265319088R34-R56)