### PR TITLE
Fix SessionStore preview initialization

### DIFF
--- a/TinniTrack/Features/Onboarding/Views/CompleteOnboardingView.swift
+++ b/TinniTrack/Features/Onboarding/Views/CompleteOnboardingView.swift
@@ -60,5 +60,10 @@ struct CompleteOnboardingView: View {
 
 #Preview {
     CompleteOnboardingView()
-        .environmentObject(SessionStore())
+        .environmentObject(
+            SessionStore(
+                authService: SupabaseAuthService(),
+                profileService: SupabaseProfileService()
+            )
+        )
 }

--- a/TinniTrack/Features/Onboarding/Views/EmailVerificationPendingView.swift
+++ b/TinniTrack/Features/Onboarding/Views/EmailVerificationPendingView.swift
@@ -75,5 +75,10 @@ struct EmailVerificationPendingView: View {
 
 #Preview {
     EmailVerificationPendingView()
-        .environmentObject(SessionStore())
+        .environmentObject(
+            SessionStore(
+                authService: SupabaseAuthService(),
+                profileService: SupabaseProfileService()
+            )
+        )
 }

--- a/TinniTrack/Features/Onboarding/Views/ResetPasswordView.swift
+++ b/TinniTrack/Features/Onboarding/Views/ResetPasswordView.swift
@@ -39,5 +39,10 @@ struct ResetPasswordView: View {
 
 #Preview {
     ResetPasswordView()
-        .environmentObject(SessionStore())
+        .environmentObject(
+            SessionStore(
+                authService: SupabaseAuthService(),
+                profileService: SupabaseProfileService()
+            )
+        )
 }

--- a/TinniTrack/Features/Onboarding/Views/SignUpView.swift
+++ b/TinniTrack/Features/Onboarding/Views/SignUpView.swift
@@ -322,5 +322,10 @@ private struct FloatingInputField: View {
     NavigationStack {
         SignUpView()
     }
-    .environmentObject(SessionStore())
+    .environmentObject(
+        SessionStore(
+            authService: SupabaseAuthService(),
+            profileService: SupabaseProfileService()
+        )
+    )
 }


### PR DESCRIPTION
Fixes SwiftUI previews failing to compile due to SessionStore requiring authService and profileService.

Updated affected previews to initialize SessionStore(authService:..., profileService:...).

Resolves #33