### PR TITLE
Fix/14 login title resizing

### DIFF
--- a/TinniTrack/Features/Onboarding/Views/LoginView.swift
+++ b/TinniTrack/Features/Onboarding/Views/LoginView.swift
@@ -55,8 +55,8 @@ struct LoginView: View {
                                 .font(.system(size: 31, weight: .bold))
                                 .foregroundStyle(.black)
                                 .lineLimit(1)
-                                .minimumScaleFactor(0.72)
-                                .allowsTightening(true)
+                                .fixedSize(horizontal: true, vertical: false)
+                                .frame(height: 40)
 
                             Text("Sign in to begin your tinnitus tracking.")
                                 .font(.system(size: 15, weight: .regular))


### PR DESCRIPTION
Removes dynamic scaling behavior from the "Welcome to TinniTrack" label so its font size remains consistent when text fields are focused.

Closes #14