### PR TITLE
Refactor SessionStore into a deterministic state machine, add typed auth errors, and centralize store composition

### DIFF
--- a/TinniTrack/Features/Dashboard/Views/HomeView.swift
+++ b/TinniTrack/Features/Dashboard/Views/HomeView.swift
@@ -38,7 +38,7 @@ struct HomeView: View {
     }
 
     private var displayFirstName: String {
-        let trimmed = sessionStore.profile?.firstName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let trimmed = sessionStore.state.profile?.firstName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? "Participant" : trimmed
     }
 }
@@ -335,8 +335,8 @@ private struct ProfileTabView: View {
     var body: some View {
         Form {
             Section("Profile") {
-                LabeledContent("First Name", value: sessionStore.profile?.firstName ?? "Not set")
-                LabeledContent("Last Name", value: sessionStore.profile?.lastName ?? "Not set")
+                LabeledContent("First Name", value: sessionStore.state.profile?.firstName ?? "Not set")
+                LabeledContent("Last Name", value: sessionStore.state.profile?.lastName ?? "Not set")
             }
 
             Section("Research") {
@@ -361,7 +361,7 @@ private struct ProfileTabView: View {
     }
 
     private var participantIDText: String {
-        guard let participantID = sessionStore.profile?.participantID else { return "Unavailable" }
+        guard let participantID = sessionStore.state.profile?.participantID else { return "Unavailable" }
         return String(participantID)
     }
 

--- a/TinniTrack/Features/Onboarding/Views/CompleteOnboardingView.swift
+++ b/TinniTrack/Features/Onboarding/Views/CompleteOnboardingView.swift
@@ -37,7 +37,7 @@ struct CompleteOnboardingView: View {
                             )
                         }
                     }
-                    .disabled(!canSubmit || sessionStore.isLoading)
+                    .disabled(!canSubmit || sessionStore.state.isBusy)
 
                     Button("Sign Out", role: .destructive) {
                         Task {
@@ -48,7 +48,7 @@ struct CompleteOnboardingView: View {
             }
             .navigationTitle("Onboarding")
             .onAppear {
-                if let profile = sessionStore.profile {
+                if let profile = sessionStore.state.profile {
                     firstName = profile.firstName ?? firstName
                     lastName = profile.lastName ?? lastName
                     dateOfBirth = profile.dateOfBirth ?? dateOfBirth
@@ -60,5 +60,5 @@ struct CompleteOnboardingView: View {
 
 #Preview {
     CompleteOnboardingView()
-        .environmentObject(SessionStore())
+        .environmentObject(SessionStoreFactory.makePreviewStore(.authenticatedNeedsOnboarding))
 }

--- a/TinniTrack/Features/Onboarding/Views/EmailVerificationPendingView.swift
+++ b/TinniTrack/Features/Onboarding/Views/EmailVerificationPendingView.swift
@@ -24,7 +24,7 @@ struct EmailVerificationPendingView: View {
                 .multilineTextAlignment(.center)
                 .accessibilityIdentifier("email_verification_title")
 
-            if let email = sessionStore.pendingVerificationEmail {
+            if let email = sessionStore.state.pendingVerificationEmail {
                 Text("We sent a verification link to \(email). Open that email on this device to continue.")
                     .font(.system(size: 16))
                     .foregroundStyle(.secondary)
@@ -75,5 +75,7 @@ struct EmailVerificationPendingView: View {
 
 #Preview {
     EmailVerificationPendingView()
-        .environmentObject(SessionStore())
+        .environmentObject(
+            SessionStoreFactory.makePreviewStore(.awaitingEmailVerification(email: "pending@example.com"))
+        )
 }

--- a/TinniTrack/Features/Onboarding/Views/LoginView.swift
+++ b/TinniTrack/Features/Onboarding/Views/LoginView.swift
@@ -102,7 +102,7 @@ struct LoginView: View {
                                     }
                                     .font(.system(size: 13, weight: .semibold))
                                     .foregroundStyle(focusColor)
-                                    .disabled(sessionStore.isLoading || normalizedEmail.isEmpty)
+                                    .disabled(sessionStore.state.isBusy || normalizedEmail.isEmpty)
                                     .accessibilityIdentifier("forgot_password_button")
                                 }
                                 .padding(.top, 2)
@@ -124,7 +124,7 @@ struct LoginView: View {
                             .background(actionColor)
                             .clipShape(Capsule())
                             .padding(.horizontal, 12)
-                            .disabled(sessionStore.isLoading || !canSubmit)
+                            .disabled(sessionStore.state.isBusy || !canSubmit)
                             .accessibilityIdentifier("login_button")
                         }
                         .padding(.horizontal, 24)
@@ -164,10 +164,10 @@ struct LoginView: View {
                 }
                 .scrollDismissesKeyboard(.interactively)
                 .scrollDisabled(focusedField == nil)
-                .allowsHitTesting(!sessionStore.isLoading)
+                .allowsHitTesting(!sessionStore.state.isBusy)
             }
 
-            if sessionStore.isLoading {
+            if sessionStore.state.isBusy {
                 ProgressView()
             }
         }
@@ -283,4 +283,5 @@ private struct LogoView: View {
     NavigationStack {
         LoginView()
     }
+    .environmentObject(SessionStoreFactory.makePreviewStore())
 }

--- a/TinniTrack/Features/Onboarding/Views/ResetPasswordView.swift
+++ b/TinniTrack/Features/Onboarding/Views/ResetPasswordView.swift
@@ -29,7 +29,7 @@ struct ResetPasswordView: View {
                             await sessionStore.submitNewPassword(newPassword)
                         }
                     }
-                    .disabled(!canSubmit || sessionStore.isLoading)
+                    .disabled(!canSubmit || sessionStore.state.isBusy)
                 }
             }
             .navigationTitle("Reset Password")
@@ -39,5 +39,5 @@ struct ResetPasswordView: View {
 
 #Preview {
     ResetPasswordView()
-        .environmentObject(SessionStore())
+        .environmentObject(SessionStoreFactory.makePreviewStore())
 }

--- a/TinniTrack/Features/Onboarding/Views/SignUpView.swift
+++ b/TinniTrack/Features/Onboarding/Views/SignUpView.swift
@@ -107,7 +107,7 @@ struct SignUpView: View {
                         .background(actionColor)
                         .clipShape(Capsule())
                         .padding(.top, 8)
-                        .disabled(!isStepOneValid || sessionStore.isLoading)
+                        .disabled(!isStepOneValid || sessionStore.state.isBusy)
                         .accessibilityIdentifier("signup_continue_button")
                     } else {
                         VStack(spacing: 14) {
@@ -180,7 +180,7 @@ struct SignUpView: View {
                                         dateOfBirth: dateOfBirth
                                     )
 
-                                    if sessionStore.phase != .unauthenticated {
+                                    if !sessionStore.state.isUnauthenticated {
                                         draftStore.clear()
                                     }
                                 }
@@ -191,7 +191,7 @@ struct SignUpView: View {
                             .frame(height: 52)
                             .background(actionColor)
                             .clipShape(Capsule())
-                            .disabled(!isStepTwoValid || sessionStore.isLoading)
+                            .disabled(!isStepTwoValid || sessionStore.state.isBusy)
                             .accessibilityIdentifier("signup_create_account_button")
                         }
                         .padding(.top, 8)
@@ -210,7 +210,7 @@ struct SignUpView: View {
                 .padding(.vertical, 18)
             }
 
-            if sessionStore.isLoading {
+            if sessionStore.state.isBusy {
                 ProgressView()
             }
         }
@@ -322,5 +322,5 @@ private struct FloatingInputField: View {
     NavigationStack {
         SignUpView()
     }
-    .environmentObject(SessionStore())
+    .environmentObject(SessionStoreFactory.makePreviewStore())
 }

--- a/TinniTrack/Services/Auth/AuthServiceProtocol.swift
+++ b/TinniTrack/Services/Auth/AuthServiceProtocol.swift
@@ -9,6 +9,29 @@ struct AuthSession: Equatable {
     let userID: UUID
 }
 
+enum AuthServiceError: Equatable, LocalizedError {
+    case emailNotConfirmed
+    case noActiveSession
+    case callbackFailed(String)
+    case transport(String)
+    case unknown(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emailNotConfirmed:
+            return "Please verify your email address before signing in."
+        case .noActiveSession:
+            return "No active session."
+        case .callbackFailed(let message):
+            return message
+        case .transport(let message):
+            return message
+        case .unknown(let message):
+            return message
+        }
+    }
+}
+
 enum SignUpResult: Equatable {
     case signedIn
     case awaitingEmailVerification
@@ -54,7 +77,6 @@ protocol AuthServiceProtocol {
     func currentSession() async throws -> AuthSession?
     func authStateStream() -> AsyncStream<AuthStateChange>
     func resendSignUpVerification(email: String, redirectURL: URL) async throws
-    func isEmailNotConfirmedError(_ error: Error) -> Bool
     func requestPasswordReset(email: String, redirectURL: URL) async throws
     func handleAuthCallback(url: URL) async throws -> AuthCallbackResult
     func updatePassword(newPassword: String) async throws

--- a/TinniTrack/Services/Auth/SupabaseAuthService.swift
+++ b/TinniTrack/Services/Auth/SupabaseAuthService.swift
@@ -36,10 +36,14 @@ final class SupabaseAuthService: AuthServiceProtocol {
     }
 
     func signIn(email: String, password: String) async throws {
-        try await client.auth.signIn(
-            email: email,
-            password: password
-        )
+        do {
+            try await client.auth.signIn(
+                email: email,
+                password: password
+            )
+        } catch {
+            throw Self.mapAuthError(error)
+        }
     }
 
     func signOut() async throws {
@@ -51,7 +55,11 @@ final class SupabaseAuthService: AuthServiceProtocol {
             let session = try await client.auth.session
             return AuthSession(userID: session.user.id)
         } catch {
-            return nil
+            let mapped = Self.mapAuthError(error)
+            if case .noActiveSession = mapped {
+                return nil
+            }
+            throw mapped
         }
     }
 
@@ -76,45 +84,47 @@ final class SupabaseAuthService: AuthServiceProtocol {
     }
 
     func resendSignUpVerification(email: String, redirectURL: URL) async throws {
-        try await client.auth.resend(
-            email: email,
-            type: .signup,
-            emailRedirectTo: redirectURL
-        )
-    }
-
-    func isEmailNotConfirmedError(_ error: Error) -> Bool {
-        let message = error.localizedDescription.lowercased()
-        return message.contains("email not confirmed")
-            || message.contains("email_not_confirmed")
-            || message.contains("email not verified")
+        do {
+            try await client.auth.resend(
+                email: email,
+                type: .signup,
+                emailRedirectTo: redirectURL
+            )
+        } catch {
+            throw Self.mapAuthError(error)
+        }
     }
 
     func requestPasswordReset(email: String, redirectURL: URL) async throws {
-        try await client.auth.resetPasswordForEmail(
-            email,
-            redirectTo: redirectURL
-        )
+        do {
+            try await client.auth.resetPasswordForEmail(
+                email,
+                redirectTo: redirectURL
+            )
+        } catch {
+            throw Self.mapAuthError(error)
+        }
     }
 
     func handleAuthCallback(url: URL) async throws -> AuthCallbackResult {
         let params = Self.authParams(from: url)
 
         if let errorDescription = params["error_description"], !errorDescription.isEmpty {
-            throw NSError(
-                domain: "AuthCallback",
-                code: 400,
-                userInfo: [NSLocalizedDescriptionKey: errorDescription.replacingOccurrences(of: "+", with: " ")]
-            )
+            let message = errorDescription.replacingOccurrences(of: "+", with: " ")
+            throw AuthServiceError.callbackFailed(message)
         }
 
-        if let accessToken = params["access_token"],
-           let refreshToken = params["refresh_token"],
-           !accessToken.isEmpty,
-           !refreshToken.isEmpty {
-            _ = try await client.auth.setSession(accessToken: accessToken, refreshToken: refreshToken)
-        } else {
-            _ = try await client.auth.session(from: url)
+        do {
+            if let accessToken = params["access_token"],
+               let refreshToken = params["refresh_token"],
+               !accessToken.isEmpty,
+               !refreshToken.isEmpty {
+                _ = try await client.auth.setSession(accessToken: accessToken, refreshToken: refreshToken)
+            } else {
+                _ = try await client.auth.session(from: url)
+            }
+        } catch {
+            throw Self.mapAuthError(error)
         }
 
         if Self.isRecoveryURL(url) {
@@ -124,9 +134,13 @@ final class SupabaseAuthService: AuthServiceProtocol {
     }
 
     func updatePassword(newPassword: String) async throws {
-        try await client.auth.update(
-            user: UserAttributes(password: newPassword)
-        )
+        do {
+            try await client.auth.update(
+                user: UserAttributes(password: newPassword)
+            )
+        } catch {
+            throw Self.mapAuthError(error)
+        }
     }
 
     private static func mapEvent(description: String) -> AuthEvent {
@@ -146,6 +160,37 @@ final class SupabaseAuthService: AuthServiceProtocol {
         default:
             return .unknown
         }
+    }
+
+    private static func mapAuthError(_ error: Error) -> AuthServiceError {
+        let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercased = message.lowercased()
+
+        if lowercased.contains("email not confirmed")
+            || lowercased.contains("email_not_confirmed")
+            || lowercased.contains("email not verified") {
+            return .emailNotConfirmed
+        }
+
+        if lowercased.contains("auth session missing")
+            || lowercased.contains("session missing")
+            || lowercased.contains("invalid refresh token")
+            || lowercased.contains("refresh token not found")
+            || lowercased.contains("session_not_found") {
+            return .noActiveSession
+        }
+
+        if lowercased.contains("network")
+            || lowercased.contains("offline")
+            || lowercased.contains("timed out")
+            || lowercased.contains("connection") {
+            return .transport(message.isEmpty ? "Network request failed." : message)
+        }
+
+        if message.isEmpty {
+            return .unknown("Authentication failed.")
+        }
+        return .unknown(message)
     }
 
     private static func isRecoveryURL(_ url: URL) -> Bool {

--- a/TinniTrack/Shared/App/AppRootView.swift
+++ b/TinniTrack/Shared/App/AppRootView.swift
@@ -10,23 +10,26 @@ struct AppRootView: View {
 
     var body: some View {
         rootContent
-        .alert("Error", isPresented: Binding(
-            get: { sessionStore.errorMessage != nil },
-            set: { _ in sessionStore.dismissError() }
+        .alert(sessionStore.state.banner?.title ?? "Info", isPresented: Binding(
+            get: { sessionStore.state.banner != nil },
+            set: { shouldPresent in
+                if !shouldPresent {
+                    sessionStore.dismissBanner()
+                }
+            }
         )) {
-            Button("OK", role: .cancel) { sessionStore.dismissError() }
+            Button("OK", role: .cancel) { sessionStore.dismissBanner() }
         } message: {
-            Text(sessionStore.errorMessage ?? "")
+            Text(sessionStore.state.banner?.message ?? "")
         }
-        .alert("Info", isPresented: Binding(
-            get: { sessionStore.infoMessage != nil },
-            set: { _ in sessionStore.dismissInfo() }
+        .fullScreenCover(isPresented: Binding(
+            get: { sessionStore.state.passwordResetPresented },
+            set: { isPresented in
+                if !isPresented {
+                    sessionStore.dismissPasswordResetSheet()
+                }
+            }
         )) {
-            Button("OK", role: .cancel) { sessionStore.dismissInfo() }
-        } message: {
-            Text(sessionStore.infoMessage ?? "")
-        }
-        .fullScreenCover(isPresented: $sessionStore.shouldPresentPasswordReset) {
             ResetPasswordView()
                 .environmentObject(sessionStore)
         }
@@ -34,21 +37,21 @@ struct AppRootView: View {
 
     @ViewBuilder
     private var rootContent: some View {
-        switch sessionStore.phase {
-        case .authenticatedReady:
+        switch sessionStore.state.route {
+        case .ready:
             HomeView()
-        case .loading, .unauthenticated, .awaitingEmailVerification, .authenticatedNeedsOnboarding:
+        case .bootstrapping, .unauthenticated, .awaitingEmailVerification, .needsOnboarding:
             NavigationStack {
-                switch sessionStore.phase {
-                case .loading:
+                switch sessionStore.state.route {
+                case .bootstrapping:
                     ProgressView("Loading…")
                 case .unauthenticated:
                     LoginView()
                 case .awaitingEmailVerification:
                     EmailVerificationPendingView()
-                case .authenticatedNeedsOnboarding:
+                case .needsOnboarding:
                     CompleteOnboardingView()
-                case .authenticatedReady:
+                case .ready:
                     EmptyView()
                 }
             }
@@ -58,4 +61,5 @@ struct AppRootView: View {
 
 #Preview {
     AppRootView()
+        .environmentObject(SessionStoreFactory.makePreviewStore())
 }

--- a/TinniTrack/Shared/App/SessionStore.swift
+++ b/TinniTrack/Shared/App/SessionStore.swift
@@ -8,71 +8,155 @@ import Combine
 
 @MainActor
 final class SessionStore: ObservableObject {
-    enum Phase: Equatable {
-        case loading
-        case unauthenticated
-        case awaitingEmailVerification
-        case authenticatedNeedsOnboarding
-        case authenticatedReady
+    struct SessionState: Equatable {
+        enum Route: Equatable {
+            case bootstrapping
+            case unauthenticated
+            case awaitingEmailVerification(email: String)
+            case needsOnboarding(profile: Profile?)
+            case ready(profile: Profile)
+        }
+
+        enum Activity: Equatable {
+            case idle
+            case signingIn
+            case signingUp
+            case completingOnboarding
+            case signingOut
+            case requestingPasswordReset
+            case handlingAuthCallback
+            case updatingPassword
+            case resendingVerificationEmail
+            case checkingVerificationStatus
+        }
+
+        enum Banner: Equatable {
+            case info(String)
+            case error(String)
+
+            var title: String {
+                switch self {
+                case .info:
+                    return "Info"
+                case .error:
+                    return "Error"
+                }
+            }
+
+            var message: String {
+                switch self {
+                case .info(let message):
+                    return message
+                case .error(let message):
+                    return message
+                }
+            }
+        }
+
+        var route: Route
+        var activity: Activity
+        var banner: Banner?
+        var passwordResetPresented: Bool
+
+        static let bootstrapping = SessionState(
+            route: .bootstrapping,
+            activity: .idle,
+            banner: nil,
+            passwordResetPresented: false
+        )
+
+        var isBusy: Bool {
+            activity != .idle
+        }
+
+        var profile: Profile? {
+            switch route {
+            case .needsOnboarding(let profile):
+                return profile
+            case .ready(let profile):
+                return profile
+            case .bootstrapping, .unauthenticated, .awaitingEmailVerification:
+                return nil
+            }
+        }
+
+        var pendingVerificationEmail: String? {
+            if case .awaitingEmailVerification(let email) = route {
+                return email
+            }
+            return nil
+        }
+
+        var isUnauthenticated: Bool {
+            if case .unauthenticated = route {
+                return true
+            }
+            return false
+        }
     }
 
-    @Published private(set) var phase: Phase = .loading
-    @Published private(set) var profile: Profile?
-    @Published private(set) var pendingVerificationEmail: String?
-    @Published var isLoading = false
-    @Published var errorMessage: String?
-    @Published var infoMessage: String?
-    @Published var shouldPresentPasswordReset = false
+    @Published private(set) var state: SessionState
 
     private let authService: AuthServiceProtocol
     private let profileService: ProfileServiceProtocol
     private let emailVerificationPendingStore: EmailVerificationPendingStoring
+    private let engine = SessionEngine()
     private var authStateTask: Task<Void, Never>?
+    private var hasStarted: Bool
 
     init(
         authService: AuthServiceProtocol,
         profileService: ProfileServiceProtocol,
-        emailVerificationPendingStore: EmailVerificationPendingStoring? = nil
+        emailVerificationPendingStore: EmailVerificationPendingStoring? = nil,
+        initialState: SessionState = SessionState(
+            route: .bootstrapping,
+            activity: .idle,
+            banner: nil,
+            passwordResetPresented: false
+        ),
+        hasStarted: Bool = false
     ) {
+        self.state = initialState
         self.authService = authService
         self.profileService = profileService
         self.emailVerificationPendingStore = emailVerificationPendingStore ?? EmailVerificationPendingStore()
-        startAuthStateListener()
-
-        Task {
-            await bootstrap()
-        }
+        self.hasStarted = hasStarted
     }
 
     deinit {
         authStateTask?.cancel()
     }
 
-    func bootstrap() async {
-        await refreshPhase()
+    func start() async {
+        await engine.run { [self] in
+            guard !hasStarted else { return }
+            hasStarted = true
+            startAuthStateListener()
+            state = .bootstrapping
+            await refreshRoute(preserveRouteOnFailure: false)
+        }
     }
 
     func signIn(email: String, password: String) async {
-        isLoading = true
-        errorMessage = nil
+        await execute(activity: .signingIn) { [self] in
+            let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        do {
-            try await authService.signIn(email: normalizedEmail, password: password)
-            clearPendingEmailVerification()
-            await refreshPhase()
-        } catch {
-            if authService.isEmailNotConfirmedError(error) {
-                setPendingEmailVerification(normalizedEmail)
-                phase = .awaitingEmailVerification
-                infoMessage = "Please verify your email address before signing in."
-            } else {
-                errorMessage = error.localizedDescription
+            do {
+                try await authService.signIn(email: normalizedEmail, password: password)
+                clearPendingEmailVerification()
+                await refreshRoute(preserveRouteOnFailure: true)
+            } catch let authError as AuthServiceError {
+                if case .emailNotConfirmed = authError {
+                    setPendingEmailVerification(normalizedEmail)
+                    state.route = .awaitingEmailVerification(email: normalizedEmail)
+                    state.banner = .info("Please verify your email address before signing in.")
+                } else {
+                    setErrorBanner(from: authError)
+                }
+            } catch {
+                setErrorBanner(from: error)
             }
         }
-
-        isLoading = false
     }
 
     func signUp(email: String, password: String, firstName: String, lastName: String, dateOfBirth: Date) async {
@@ -82,90 +166,110 @@ final class SessionStore: ObservableObject {
             dateOfBirth: dateOfBirth
         )
 
-        isLoading = true
-        errorMessage = nil
+        await execute(activity: .signingUp) { [self] in
+            let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+            do {
+                let result = try await authService.signUp(
+                    email: normalizedEmail,
+                    password: password,
+                    metadata: metadata
+                )
 
-        do {
-            let result = try await authService.signUp(
-                email: normalizedEmail,
-                password: password,
-                metadata: metadata
-            )
+                switch result {
+                case .signedIn:
+                    clearPendingEmailVerification()
+                case .awaitingEmailVerification:
+                    setPendingEmailVerification(normalizedEmail)
+                    state.route = .awaitingEmailVerification(email: normalizedEmail)
+                    state.banner = .info("Check your email to verify your account.")
+                }
 
-            switch result {
-            case .signedIn:
-                clearPendingEmailVerification()
-            case .awaitingEmailVerification:
-                setPendingEmailVerification(normalizedEmail)
-                infoMessage = "Check your email to verify your account."
+                await refreshRoute(preserveRouteOnFailure: true)
+            } catch {
+                setErrorBanner(from: error)
             }
-
-            await refreshPhase()
-        } catch {
-            errorMessage = error.localizedDescription
         }
-
-        isLoading = false
     }
 
     func completeOnboarding(firstName: String, lastName: String, dateOfBirth: Date) async {
-        await runAuthAction { [self] in
-            try await self.profileService.completeOnboarding(
-                firstName: firstName,
-                lastName: lastName,
-                dateOfBirth: dateOfBirth
-            )
+        await execute(activity: .completingOnboarding) { [self] in
+            do {
+                try await profileService.completeOnboarding(
+                    firstName: firstName,
+                    lastName: lastName,
+                    dateOfBirth: dateOfBirth
+                )
+                await refreshRoute(preserveRouteOnFailure: true)
+            } catch {
+                setErrorBanner(from: error)
+            }
         }
     }
 
     func signOut() async {
-        await runAuthAction { [self] in
-            try await self.authService.signOut()
+        await execute(activity: .signingOut) { [self] in
+            do {
+                try await authService.signOut()
+                clearPendingEmailVerification()
+                state.route = routeForNoSession()
+            } catch {
+                setErrorBanner(from: error)
+            }
         }
     }
 
     func requestPasswordReset(email: String) async {
         guard let redirectURL = URL(string: "tinnitrack://auth/reset") else { return }
 
-        await runAuthAction { [self] in
-            try await self.authService.requestPasswordReset(email: email, redirectURL: redirectURL)
-            self.infoMessage = "If the account exists, a reset email has been sent."
+        await execute(activity: .requestingPasswordReset) { [self] in
+            do {
+                try await authService.requestPasswordReset(email: email, redirectURL: redirectURL)
+                state.banner = .info("If the account exists, a reset email has been sent.")
+            } catch {
+                setErrorBanner(from: error)
+            }
         }
     }
 
     func handleIncomingURL(_ url: URL) async {
-        do {
-            let result = try await authService.handleAuthCallback(url: url)
-            switch result {
-            case .passwordRecovery:
-                shouldPresentPasswordReset = true
-            case .signedIn:
-                clearPendingEmailVerification()
-            case .none:
-                break
+        await execute(activity: .handlingAuthCallback) { [self] in
+            do {
+                let result = try await authService.handleAuthCallback(url: url)
+                switch result {
+                case .passwordRecovery:
+                    state.passwordResetPresented = true
+                case .signedIn:
+                    clearPendingEmailVerification()
+                case .none:
+                    break
+                }
+                await refreshRoute(preserveRouteOnFailure: true)
+            } catch {
+                setErrorBanner(from: error)
             }
-            await refreshPhase()
-        } catch {
-            errorMessage = error.localizedDescription
         }
     }
 
     func submitNewPassword(_ newPassword: String) async {
-        await runAuthAction { [self] in
-            try await self.authService.updatePassword(newPassword: newPassword)
-            self.shouldPresentPasswordReset = false
-            self.infoMessage = "Password updated."
+        await execute(activity: .updatingPassword) { [self] in
+            do {
+                try await authService.updatePassword(newPassword: newPassword)
+                state.passwordResetPresented = false
+                state.banner = .info("Password updated.")
+                await refreshRoute(preserveRouteOnFailure: true)
+            } catch {
+                setErrorBanner(from: error)
+            }
         }
     }
 
-    func dismissError() {
-        errorMessage = nil
+    func dismissBanner() {
+        state.banner = nil
     }
 
-    func dismissInfo() {
-        infoMessage = nil
+    func dismissPasswordResetSheet() {
+        state.passwordResetPresented = false
     }
 
     func resendVerificationEmail() async {
@@ -174,79 +278,84 @@ final class SessionStore: ObservableObject {
             return
         }
 
-        await runAuthAction { [self] in
-            try await authService.resendSignUpVerification(email: pending.email, redirectURL: redirectURL)
-            emailVerificationPendingStore.updateLastResend(at: Date())
-            infoMessage = "Verification email sent."
+        await execute(activity: .resendingVerificationEmail) { [self] in
+            do {
+                try await authService.resendSignUpVerification(email: pending.email, redirectURL: redirectURL)
+                emailVerificationPendingStore.updateLastResend(at: Date())
+                state.banner = .info("Verification email sent.")
+            } catch {
+                setErrorBanner(from: error)
+            }
         }
     }
 
     func checkEmailVerificationStatus() async {
-        await refreshPhase()
-        if phase == .awaitingEmailVerification {
-            infoMessage = "Still waiting for verification. Open the email link on this device."
+        await execute(activity: .checkingVerificationStatus) { [self] in
+            await refreshRoute(preserveRouteOnFailure: true)
+            if case .awaitingEmailVerification = state.route {
+                state.banner = .info("Still waiting for verification. Open the email link on this device.")
+            }
         }
     }
 
     func useDifferentEmailForVerification() {
         clearPendingEmailVerification()
-        phase = .unauthenticated
+        state.route = .unauthenticated
     }
 
     private func startAuthStateListener() {
         authStateTask?.cancel()
-        authStateTask = Task { [weak self] in
+        authStateTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            for await _ in authService.authStateStream() {
-                await refreshPhase()
+            for await _ in self.authService.authStateStream() {
+                await self.engine.run { [self] in
+                    await self.refreshRoute(preserveRouteOnFailure: true)
+                }
             }
         }
     }
 
-    private func refreshPhase() async {
-        phase = .loading
+    private func execute(
+        activity: SessionState.Activity,
+        clearBanner: Bool = true,
+        _ operation: @escaping @MainActor () async -> Void
+    ) async {
+        await engine.run { [self] in
+            state.activity = activity
+            if clearBanner {
+                state.banner = nil
+            }
+            defer { state.activity = .idle }
+            await operation()
+        }
+    }
+
+    private func refreshRoute(preserveRouteOnFailure: Bool) async {
+        let previousRoute = state.route
 
         do {
-            guard try await authService.currentSession() != nil else {
-                profile = nil
-                if let pending = emailVerificationPendingStore.load() {
-                    pendingVerificationEmail = pending.email
-                    phase = .awaitingEmailVerification
-                } else {
-                    pendingVerificationEmail = nil
-                    phase = .unauthenticated
-                }
+            let session = try await authService.currentSession()
+            guard session != nil else {
+                state.route = routeForNoSession()
                 return
             }
 
             clearPendingEmailVerification()
             let latestProfile = try await profileService.fetchMyProfile()
-            profile = latestProfile
 
-            if latestProfile?.isOnboardingComplete == true {
-                phase = .authenticatedReady
+            if let latestProfile, latestProfile.isOnboardingComplete {
+                state.route = .ready(profile: latestProfile)
             } else {
-                phase = .authenticatedNeedsOnboarding
+                state.route = .needsOnboarding(profile: latestProfile)
             }
         } catch {
-            errorMessage = error.localizedDescription
-            profile = nil
-            phase = .unauthenticated
+            setErrorBanner(from: error)
+            if preserveRouteOnFailure {
+                state.route = previousRoute
+            } else {
+                state.route = routeForNoSession()
+            }
         }
-    }
-
-    private func runAuthAction(_ action: @escaping () async throws -> Void) async {
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            try await action()
-            await refreshPhase()
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-
-        isLoading = false
     }
 
     private func setPendingEmailVerification(_ email: String) {
@@ -259,11 +368,47 @@ final class SessionStore: ObservableObject {
                 lastResendAt: nil
             )
         )
-        pendingVerificationEmail = normalized
     }
 
     private func clearPendingEmailVerification() {
         emailVerificationPendingStore.clear()
-        pendingVerificationEmail = nil
+    }
+
+    private func routeForNoSession() -> SessionState.Route {
+        guard let pending = emailVerificationPendingStore.load() else {
+            return .unauthenticated
+        }
+        return .awaitingEmailVerification(email: pending.email)
+    }
+
+    private func setErrorBanner(from error: Error) {
+        if let authError = error as? AuthServiceError,
+           let description = authError.errorDescription,
+           !description.isEmpty {
+            state.banner = .error(description)
+        } else {
+            state.banner = .error(error.localizedDescription)
+        }
+    }
+}
+
+@MainActor
+private final class SessionEngine {
+    private var tail: Task<Void, Never>?
+
+    func run(_ operation: @escaping @MainActor () async -> Void) async {
+        let previous = tail
+        await withCheckedContinuation { continuation in
+            let current = Task { @MainActor in
+                if let previous {
+                    _ = await previous.result
+                }
+                await operation()
+                continuation.resume()
+            }
+            tail = Task { @MainActor in
+                _ = await current.result
+            }
+        }
     }
 }

--- a/TinniTrack/TinniTrackApp.swift
+++ b/TinniTrack/TinniTrackApp.swift
@@ -11,13 +11,16 @@ struct TinniTrackApp: App {
     @StateObject private var sessionStore: SessionStore
 
     init() {
-        _sessionStore = StateObject(wrappedValue: Self.makeSessionStore())
+        _sessionStore = StateObject(wrappedValue: SessionStoreFactory.makeAppStore())
     }
 
     var body: some Scene {
         WindowGroup {
             AppRootView()
                 .environmentObject(sessionStore)
+                .task {
+                    await sessionStore.start()
+                }
                 .onOpenURL { url in
                     Task {
                         await sessionStore.handleIncomingURL(url)
@@ -25,12 +28,14 @@ struct TinniTrackApp: App {
                 }
         }
     }
+}
 
-    private static func makeSessionStore() -> SessionStore {
+enum SessionStoreFactory {
+    static func makeAppStore(processInfo: ProcessInfo = .processInfo) -> SessionStore {
         let pendingStore = EmailVerificationPendingStore()
 
-        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-            let env = ProcessInfo.processInfo.environment
+        if processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            let env = processInfo.environment
             if env["UITEST_CLEAR_PENDING_VERIFICATION"] == "1" {
                 pendingStore.clear()
             }
@@ -50,7 +55,7 @@ struct TinniTrackApp: App {
             }
 
             return SessionStore(
-                authService: NoopAuthService(),
+                authService: NoopAuthService(processInfo: processInfo),
                 profileService: NoopProfileService(),
                 emailVerificationPendingStore: pendingStore
             )
@@ -62,6 +67,81 @@ struct TinniTrackApp: App {
             emailVerificationPendingStore: pendingStore
         )
     }
+
+    #if DEBUG
+    enum PreviewScenario {
+        case unauthenticated
+        case awaitingEmailVerification(email: String)
+        case authenticatedNeedsOnboarding
+        case authenticatedReady
+    }
+
+    static func makePreviewStore(_ scenario: PreviewScenario = .unauthenticated) -> SessionStore {
+        let previewUserID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let previewDateOfBirth = Calendar.current.date(byAdding: .year, value: -30, to: Date()) ?? Date()
+
+        let pending: PendingEmailVerification?
+        let session: AuthSession?
+        let profile: Profile?
+        let route: SessionStore.SessionState.Route
+
+        switch scenario {
+        case .unauthenticated:
+            pending = nil
+            session = nil
+            profile = nil
+            route = .unauthenticated
+        case .awaitingEmailVerification(let email):
+            let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+            let safeEmail = trimmedEmail.isEmpty ? "pending@example.com" : trimmedEmail
+            pending = PendingEmailVerification(email: safeEmail, createdAt: Date(), lastResendAt: nil)
+            session = nil
+            profile = nil
+            route = .awaitingEmailVerification(email: safeEmail)
+        case .authenticatedNeedsOnboarding:
+            pending = nil
+            session = AuthSession(userID: previewUserID)
+            profile = Profile(
+                id: previewUserID,
+                participantID: nil,
+                firstName: "Taylor",
+                lastName: "Rivers",
+                dateOfBirth: previewDateOfBirth,
+                timezone: "America/New_York",
+                createdAt: Date(),
+                onboardingCompletedAt: nil
+            )
+            route = .needsOnboarding(profile: profile)
+        case .authenticatedReady:
+            pending = nil
+            session = AuthSession(userID: previewUserID)
+            profile = Profile(
+                id: previewUserID,
+                participantID: 1001,
+                firstName: "Taylor",
+                lastName: "Rivers",
+                dateOfBirth: previewDateOfBirth,
+                timezone: "America/New_York",
+                createdAt: Date(),
+                onboardingCompletedAt: Date()
+            )
+            route = .ready(profile: profile!)
+        }
+
+        return SessionStore(
+            authService: PreviewAuthService(session: session),
+            profileService: StaticProfileService(profile: profile),
+            emailVerificationPendingStore: InMemoryEmailVerificationPendingStore(pending: pending),
+            initialState: SessionStore.SessionState(
+                route: route,
+                activity: .idle,
+                banner: nil,
+                passwordResetPresented: false
+            ),
+            hasStarted: true
+        )
+    }
+    #endif
 }
 
 private final class NoopAuthService: AuthServiceProtocol {
@@ -79,27 +159,127 @@ private final class NoopAuthService: AuthServiceProtocol {
     func signUp(email: String, password: String, metadata: SignUpMetadata) async throws -> SignUpResult {
         .awaitingEmailVerification
     }
+
     func signIn(email: String, password: String) async throws {}
+
     func signOut() async throws {}
+
     func currentSession() async throws -> AuthSession? {
         currentSessionCallCount += 1
         guard let verifyAfterSessionChecks else { return nil }
         guard currentSessionCallCount >= verifyAfterSessionChecks else { return nil }
         return AuthSession(userID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
     }
+
     func authStateStream() -> AsyncStream<AuthStateChange> {
         AsyncStream { continuation in
             continuation.finish()
         }
     }
+
     func resendSignUpVerification(email: String, redirectURL: URL) async throws {}
-    func isEmailNotConfirmedError(_ error: Error) -> Bool { false }
+
     func requestPasswordReset(email: String, redirectURL: URL) async throws {}
+
     func handleAuthCallback(url: URL) async throws -> AuthCallbackResult { .none }
+
     func updatePassword(newPassword: String) async throws {}
 }
 
 private final class NoopProfileService: ProfileServiceProtocol {
     func fetchMyProfile() async throws -> Profile? { nil }
+
     func completeOnboarding(firstName: String, lastName: String, dateOfBirth: Date) async throws {}
 }
+
+#if DEBUG
+private final class PreviewAuthService: AuthServiceProtocol {
+    private var session: AuthSession?
+
+    init(session: AuthSession?) {
+        self.session = session
+    }
+
+    func signUp(email: String, password: String, metadata: SignUpMetadata) async throws -> SignUpResult {
+        .awaitingEmailVerification
+    }
+
+    func signIn(email: String, password: String) async throws {
+        let userID = session?.userID ?? UUID()
+        session = AuthSession(userID: userID)
+    }
+
+    func signOut() async throws {
+        session = nil
+    }
+
+    func currentSession() async throws -> AuthSession? {
+        session
+    }
+
+    func authStateStream() -> AsyncStream<AuthStateChange> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func resendSignUpVerification(email: String, redirectURL: URL) async throws {}
+
+    func requestPasswordReset(email: String, redirectURL: URL) async throws {}
+
+    func handleAuthCallback(url: URL) async throws -> AuthCallbackResult { .none }
+
+    func updatePassword(newPassword: String) async throws {}
+}
+
+private final class StaticProfileService: ProfileServiceProtocol {
+    private var profile: Profile?
+
+    init(profile: Profile?) {
+        self.profile = profile
+    }
+
+    func fetchMyProfile() async throws -> Profile? {
+        profile
+    }
+
+    func completeOnboarding(firstName: String, lastName: String, dateOfBirth: Date) async throws {
+        profile = Profile(
+            id: profile?.id ?? UUID(),
+            participantID: profile?.participantID,
+            firstName: firstName,
+            lastName: lastName,
+            dateOfBirth: dateOfBirth,
+            timezone: profile?.timezone,
+            createdAt: profile?.createdAt,
+            onboardingCompletedAt: Date()
+        )
+    }
+}
+
+private final class InMemoryEmailVerificationPendingStore: EmailVerificationPendingStoring {
+    private var pending: PendingEmailVerification?
+
+    init(pending: PendingEmailVerification?) {
+        self.pending = pending
+    }
+
+    func load() -> PendingEmailVerification? {
+        pending
+    }
+
+    func save(_ pending: PendingEmailVerification) {
+        self.pending = pending
+    }
+
+    func updateLastResend(at date: Date) {
+        guard var pending else { return }
+        pending.lastResendAt = date
+        self.pending = pending
+    }
+
+    func clear() {
+        pending = nil
+    }
+}
+#endif

--- a/TinniTrackTests/SessionStoreTests.swift
+++ b/TinniTrackTests/SessionStoreTests.swift
@@ -5,19 +5,19 @@ import Testing
 @MainActor
 struct SessionStoreTests {
     @Test
-    func bootstrapMovesToUnauthenticatedWhenNoSession() async {
+    func startMovesToUnauthenticatedWhenNoSession() async {
         let auth = MockAuthService(currentSession: nil)
         let profile = MockProfileService(profile: nil)
         let pending = MockEmailVerificationPendingStore(pending: nil)
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
-        await store.bootstrap()
+        await store.start()
 
-        #expect(store.phase == .unauthenticated)
+        #expect(store.state.route == .unauthenticated)
     }
 
     @Test
-    func bootstrapMovesToAwaitingVerificationWhenPendingEmailExists() async {
+    func startMovesToAwaitingVerificationWhenPendingEmailExists() async {
         let auth = MockAuthService(currentSession: nil)
         let profile = MockProfileService(profile: nil)
         let pending = MockEmailVerificationPendingStore(
@@ -29,14 +29,14 @@ struct SessionStoreTests {
         )
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
-        await store.bootstrap()
+        await store.start()
 
-        #expect(store.phase == .awaitingEmailVerification)
-        #expect(store.pendingVerificationEmail == "pending@example.com")
+        #expect(store.state.route == .awaitingEmailVerification(email: "pending@example.com"))
+        #expect(store.state.pendingVerificationEmail == "pending@example.com")
     }
 
     @Test
-    func bootstrapMovesToNeedsOnboardingWhenSessionExistsWithoutCompletion() async {
+    func startMovesToNeedsOnboardingWhenSessionExistsWithoutCompletion() async {
         let userID = UUID()
         let auth = MockAuthService(currentSession: AuthSession(userID: userID))
         let profile = MockProfileService(
@@ -54,13 +54,17 @@ struct SessionStoreTests {
         let pending = MockEmailVerificationPendingStore(pending: nil)
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
-        await store.bootstrap()
+        await store.start()
 
-        #expect(store.phase == .authenticatedNeedsOnboarding)
+        if case .needsOnboarding(let loadedProfile) = store.state.route {
+            #expect(loadedProfile?.id == userID)
+        } else {
+            #expect(Bool(false), "Expected .needsOnboarding route")
+        }
     }
 
     @Test
-    func bootstrapMovesToReadyWhenProfileCompleted() async {
+    func startMovesToReadyWhenProfileCompleted() async {
         let userID = UUID()
         let auth = MockAuthService(currentSession: AuthSession(userID: userID))
         let profile = MockProfileService(
@@ -80,19 +84,24 @@ struct SessionStoreTests {
         )
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
-        await store.bootstrap()
+        await store.start()
 
-        #expect(store.phase == .authenticatedReady)
-        #expect(store.pendingVerificationEmail == nil)
+        if case .ready(let loadedProfile) = store.state.route {
+            #expect(loadedProfile.id == userID)
+        } else {
+            #expect(Bool(false), "Expected .ready route")
+        }
+        #expect(store.state.pendingVerificationEmail == nil)
     }
 
     @Test
-    func signUpAwaitingVerificationStoresPendingAndMovesToAwaitingPhase() async {
+    func signUpAwaitingVerificationStoresPendingAndMovesToAwaitingRoute() async {
         let auth = MockAuthService(currentSession: nil, signUpResult: .awaitingEmailVerification)
         let profile = MockProfileService(profile: nil)
         let pending = MockEmailVerificationPendingStore(pending: nil)
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
+        await store.start()
         await store.signUp(
             email: "pending@example.com",
             password: "password123",
@@ -101,8 +110,8 @@ struct SessionStoreTests {
             dateOfBirth: Date()
         )
 
-        #expect(store.phase == .awaitingEmailVerification)
-        #expect(store.pendingVerificationEmail == "pending@example.com")
+        #expect(store.state.route == .awaitingEmailVerification(email: "pending@example.com"))
+        #expect(store.state.pendingVerificationEmail == "pending@example.com")
         #expect(pending.pending?.email == "pending@example.com")
     }
 
@@ -110,16 +119,17 @@ struct SessionStoreTests {
     func signInUnconfirmedEmailMovesToAwaitingVerification() async {
         let auth = MockAuthService(
             currentSession: nil,
-            signInError: MockAuthError.emailNotConfirmed
+            signInError: AuthServiceError.emailNotConfirmed
         )
         let profile = MockProfileService(profile: nil)
         let pending = MockEmailVerificationPendingStore(pending: nil)
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
+        await store.start()
         await store.signIn(email: "pending@example.com", password: "password123")
 
-        #expect(store.phase == .awaitingEmailVerification)
-        #expect(store.pendingVerificationEmail == "pending@example.com")
+        #expect(store.state.route == .awaitingEmailVerification(email: "pending@example.com"))
+        #expect(store.state.pendingVerificationEmail == "pending@example.com")
         #expect(pending.pending?.email == "pending@example.com")
     }
 
@@ -141,11 +151,16 @@ struct SessionStoreTests {
         )
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
+        await store.start()
         await store.handleIncomingURL(URL(string: "tinnitrack://auth/confirm#access_token=123")!)
 
-        #expect(store.phase == .authenticatedNeedsOnboarding)
-        #expect(store.pendingVerificationEmail == nil)
+        #expect(store.state.pendingVerificationEmail == nil)
         #expect(pending.pending == nil)
+        if case .needsOnboarding = store.state.route {
+            #expect(Bool(true))
+        } else {
+            #expect(Bool(false), "Expected .needsOnboarding route")
+        }
     }
 
     @Test
@@ -161,12 +176,115 @@ struct SessionStoreTests {
         )
         let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
 
-        await store.bootstrap()
+        await store.start()
         store.useDifferentEmailForVerification()
 
-        #expect(store.phase == .unauthenticated)
-        #expect(store.pendingVerificationEmail == nil)
+        #expect(store.state.route == .unauthenticated)
+        #expect(store.state.pendingVerificationEmail == nil)
         #expect(pending.pending == nil)
+    }
+
+    @Test
+    func refreshFailurePreservesExistingRouteAndShowsError() async {
+        let userID = UUID()
+        let profile = Profile(
+            id: userID,
+            participantID: nil,
+            firstName: "Jane",
+            lastName: "Doe",
+            dateOfBirth: Date(),
+            timezone: nil,
+            createdAt: nil,
+            onboardingCompletedAt: Date()
+        )
+
+        let auth = MockAuthService(currentSession: AuthSession(userID: userID))
+        let profileService = MockProfileService(profile: profile)
+        let pending = MockEmailVerificationPendingStore(pending: nil)
+        let store = SessionStore(authService: auth, profileService: profileService, emailVerificationPendingStore: pending)
+
+        await store.start()
+        auth.currentSessionError = AuthServiceError.transport("Network unavailable")
+
+        await store.checkEmailVerificationStatus()
+
+        if case .ready = store.state.route {
+            #expect(Bool(true))
+        } else {
+            #expect(Bool(false), "Expected existing .ready route to be preserved")
+        }
+
+        if case .error(let message)? = store.state.banner {
+            #expect(message == "Network unavailable")
+        } else {
+            #expect(Bool(false), "Expected error banner after refresh failure")
+        }
+    }
+
+    @Test
+    func concurrentRefreshRequestsRunSerialized() async {
+        let recorder = CurrentSessionConcurrencyRecorder()
+        let auth = MockAuthService(
+            currentSession: nil,
+            currentSessionDelayNanoseconds: 80_000_000,
+            currentSessionRecorder: recorder
+        )
+        let profile = MockProfileService(profile: nil)
+        let pending = MockEmailVerificationPendingStore(
+            pending: PendingEmailVerification(
+                email: "pending@example.com",
+                createdAt: Date(),
+                lastResendAt: nil
+            )
+        )
+        let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
+
+        await store.start()
+
+        let taskOne = Task { @MainActor in
+            await store.checkEmailVerificationStatus()
+        }
+        let taskTwo = Task { @MainActor in
+            await store.checkEmailVerificationStatus()
+        }
+
+        await taskOne.value
+        await taskTwo.value
+
+        #expect(recorder.snapshotMaxInFlight() == 1)
+    }
+
+    @Test
+    func signInMaintainsRouteStabilityWithoutBootstrappingFlicker() async {
+        let userID = UUID()
+        let auth = MockAuthService(
+            currentSession: nil,
+            sessionAfterSignIn: AuthSession(userID: userID),
+            signInDelayNanoseconds: 80_000_000
+        )
+        let profile = MockProfileService(profile: nil)
+        let pending = MockEmailVerificationPendingStore(pending: nil)
+        let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
+
+        await store.start()
+
+        let task = Task { @MainActor in
+            await store.signIn(email: "person@example.com", password: "password123")
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        #expect(store.state.route == .unauthenticated)
+        #expect(store.state.activity == .signingIn)
+
+        await task.value
+
+        if case .needsOnboarding = store.state.route {
+            #expect(Bool(true))
+        } else {
+            #expect(Bool(false), "Expected .needsOnboarding after successful sign-in")
+        }
+        #expect(store.state.route != .bootstrapping)
     }
 }
 
@@ -176,19 +294,34 @@ private final class MockAuthService: AuthServiceProtocol {
     private let signInError: Error?
     private let callbackResult: AuthCallbackResult
     private let callbackSession: AuthSession?
+    private let sessionAfterSignIn: AuthSession?
+    private let signInDelayNanoseconds: UInt64
+    var currentSessionError: Error?
+    private let currentSessionDelayNanoseconds: UInt64
+    private let currentSessionRecorder: CurrentSessionConcurrencyRecorder?
 
     init(
         currentSession: AuthSession?,
         signUpResult: SignUpResult = .signedIn,
         signInError: Error? = nil,
         callbackResult: AuthCallbackResult = .none,
-        callbackSession: AuthSession? = nil
+        callbackSession: AuthSession? = nil,
+        sessionAfterSignIn: AuthSession? = nil,
+        signInDelayNanoseconds: UInt64 = 0,
+        currentSessionError: Error? = nil,
+        currentSessionDelayNanoseconds: UInt64 = 0,
+        currentSessionRecorder: CurrentSessionConcurrencyRecorder? = nil
     ) {
         self.storedSession = currentSession
         self.signUpResult = signUpResult
         self.signInError = signInError
         self.callbackResult = callbackResult
         self.callbackSession = callbackSession
+        self.sessionAfterSignIn = sessionAfterSignIn
+        self.signInDelayNanoseconds = signInDelayNanoseconds
+        self.currentSessionError = currentSessionError
+        self.currentSessionDelayNanoseconds = currentSessionDelayNanoseconds
+        self.currentSessionRecorder = currentSessionRecorder
     }
 
     func signUp(email: String, password: String, metadata: SignUpMetadata) async throws -> SignUpResult {
@@ -196,8 +329,14 @@ private final class MockAuthService: AuthServiceProtocol {
     }
 
     func signIn(email: String, password: String) async throws {
+        if signInDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: signInDelayNanoseconds)
+        }
         if let signInError {
             throw signInError
+        }
+        if let sessionAfterSignIn {
+            storedSession = sessionAfterSignIn
         }
     }
 
@@ -206,7 +345,16 @@ private final class MockAuthService: AuthServiceProtocol {
     }
 
     func currentSession() async throws -> AuthSession? {
-        storedSession
+        currentSessionRecorder?.begin()
+        defer { currentSessionRecorder?.end() }
+
+        if currentSessionDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: currentSessionDelayNanoseconds)
+        }
+        if let currentSessionError {
+            throw currentSessionError
+        }
+        return storedSession
     }
 
     func authStateStream() -> AsyncStream<AuthStateChange> {
@@ -216,17 +364,16 @@ private final class MockAuthService: AuthServiceProtocol {
     }
 
     func resendSignUpVerification(email: String, redirectURL: URL) async throws {}
-    func isEmailNotConfirmedError(_ error: Error) -> Bool {
-        guard let mockError = error as? MockAuthError else { return false }
-        return mockError == .emailNotConfirmed
-    }
+
     func requestPasswordReset(email: String, redirectURL: URL) async throws {}
+
     func handleAuthCallback(url: URL) async throws -> AuthCallbackResult {
         if callbackResult == .signedIn {
             storedSession = callbackSession
         }
         return callbackResult
     }
+
     func updatePassword(newPassword: String) async throws {}
 }
 
@@ -255,17 +402,6 @@ private final class MockProfileService: ProfileServiceProtocol {
     }
 }
 
-private enum MockAuthError: LocalizedError {
-    case emailNotConfirmed
-
-    var errorDescription: String? {
-        switch self {
-        case .emailNotConfirmed:
-            return "Email not confirmed"
-        }
-    }
-}
-
 private final class MockEmailVerificationPendingStore: EmailVerificationPendingStoring {
     var pending: PendingEmailVerification?
 
@@ -289,5 +425,32 @@ private final class MockEmailVerificationPendingStore: EmailVerificationPendingS
 
     func clear() {
         pending = nil
+    }
+}
+
+private final class CurrentSessionConcurrencyRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inFlight = 0
+    private var maxInFlight = 0
+
+    func begin() {
+        lock.lock()
+        defer { lock.unlock() }
+        inFlight += 1
+        if inFlight > maxInFlight {
+            maxInFlight = inFlight
+        }
+    }
+
+    func end() {
+        lock.lock()
+        defer { lock.unlock() }
+        inFlight = max(0, inFlight - 1)
+    }
+
+    func snapshotMaxInFlight() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return maxInFlight
     }
 }


### PR DESCRIPTION
### Quick Summary
This PR hardens session/auth/onboarding flow orchestration by replacing fragmented `SessionStore` state with a single canonical `SessionState`, serializing async transitions, and switching auth error handling to typed domain errors. It also centralizes `SessionStore` construction (app, UI test, preview) to prevent constructor drift issues and updates views/tests to consume the new state model.

### Why
The prior implementation mixed routing, operation state, and UI flags across multiple published properties, which made invalid combinations possible and introduced race-prone refresh behavior. It also treated some auth service failures as “logged out,” which masked transport/service failures and caused incorrect routing.

### What changed

### 1. `SessionStore` → canonical state snapshot
- Replaced multiple published properties (`phase`, `isLoading`, `errorMessage`, `infoMessage`, `shouldPresentPasswordReset`, `pendingVerificationEmail`, `profile`) with:
  - `@Published private(set) var state: SessionState`
- Introduced:
  - `SessionState.Route`: `.bootstrapping`, `.unauthenticated`, `.awaitingEmailVerification(email:)`, `.needsOnboarding(profile:)`, `.ready(profile:)`
  - `SessionState.Activity`: per-command activity state
  - `SessionState.Banner`: typed info/error presentation
- Replaced `bootstrap()` with `start()` as the single startup entrypoint.

### 2. Deterministic transition execution
- Added `SessionEngine` to serialize async transitions and prevent overlapping refresh/action races.
- Auth stream updates and user-triggered actions now pass through the same serialized path.
- Removed route churn during normal operations by limiting bootstrapping route to app startup.

### 3. Route refresh semantics
- `refreshRoute(preserveRouteOnFailure:)` now preserves current route for non-startup failures.
- Startup still resolves from bootstrapping to the correct no-session/session route.
- Pending verification email handling remains persisted and is cleared on verified session.

### 4. Typed auth errors
- Added `AuthServiceError` (`emailNotConfirmed`, `noActiveSession`, `callbackFailed`, `transport`, `unknown`) in `AuthServiceProtocol`.
- Updated `SupabaseAuthService` to map provider errors into `AuthServiceError`.
- `currentSession()` now returns `nil` only for true no-session cases and throws on transport/service failures.

### 5. Composition root consolidation
- Added `SessionStoreFactory` to build stores for:
  - production app
  - UI tests
  - previews
- Updated app entry to use the factory and call `await sessionStore.start()` once.
- Removed scattered direct `SessionStore()` creation patterns that caused constructor drift bugs.

### 6. UI updates to consume `state`
- Updated `AppRootView` routing, alert binding, and reset-password presentation to use `sessionStore.state`.
- Updated onboarding/auth/home views to read `state.isBusy`, `state.profile`, `state.pendingVerificationEmail`, and route-derived helpers.
- Fixed preview wiring to use centralized preview factory scenarios.

### 7. Test refactor + coverage expansion
- Migrated `SessionStoreTests` from old `phase/bootstrap` API to `state.route/start()`.
- Added tests for:
  - startup route matrix
  - refresh failure route preservation
  - concurrent refresh serialization
  - no bootstrapping flicker during sign-in
  - verification pending transitions

## Behavior changes worth noting
- App shows bootstrapping route only during startup, not during routine refreshes.
- Transport/auth service failures no longer masquerade as signed-out state.
- Session/auth/onboarding transitions are serialized to avoid stale overwrite races.