### PR TITLE
Handle auth backend outages gracefully

### DIFF
--- a/TinniTrack/Services/Auth/AuthServiceProtocol.swift
+++ b/TinniTrack/Services/Auth/AuthServiceProtocol.swift
@@ -10,6 +10,8 @@ struct AuthSession: Equatable {
 }
 
 enum AuthServiceError: Equatable, LocalizedError {
+    static let serviceUnavailableMessage = "We couldn't reach TinniTrack's servers. Please check your connection or try again later."
+
     case emailNotConfirmed
     case noActiveSession
     case callbackFailed(String)
@@ -24,8 +26,8 @@ enum AuthServiceError: Equatable, LocalizedError {
             return "No active session."
         case .callbackFailed(let message):
             return message
-        case .transport(let message):
-            return message
+        case .transport:
+            return Self.serviceUnavailableMessage
         case .unknown(let message):
             return message
         }

--- a/TinniTrack/Services/Auth/SupabaseAuthService.swift
+++ b/TinniTrack/Services/Auth/SupabaseAuthService.swift
@@ -25,14 +25,17 @@ final class SupabaseAuthService: AuthServiceProtocol {
             data["date_of_birth"] = .string(Self.dateOnlyFormatter.string(from: dateOfBirth))
         }
 
-        let response = try await client.auth.signUp(
-            email: email,
-            password: password,
-            data: data,
-            redirectTo: Self.confirmEmailRedirectURL
-        )
-
-        return response.session == nil ? .awaitingEmailVerification : .signedIn
+        do {
+            let response = try await client.auth.signUp(
+                email: email,
+                password: password,
+                data: data,
+                redirectTo: Self.confirmEmailRedirectURL
+            )
+            return response.session == nil ? .awaitingEmailVerification : .signedIn
+        } catch {
+            throw Self.mapAuthError(error)
+        }
     }
 
     func signIn(email: String, password: String) async throws {
@@ -47,7 +50,11 @@ final class SupabaseAuthService: AuthServiceProtocol {
     }
 
     func signOut() async throws {
-        try await client.auth.signOut()
+        do {
+            try await client.auth.signOut()
+        } catch {
+            throw Self.mapAuthError(error)
+        }
     }
 
     func currentSession() async throws -> AuthSession? {
@@ -163,6 +170,10 @@ final class SupabaseAuthService: AuthServiceProtocol {
     }
 
     private static func mapAuthError(_ error: Error) -> AuthServiceError {
+        if let authError = error as? AuthServiceError {
+            return authError
+        }
+
         let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         let lowercased = message.lowercased()
 
@@ -180,10 +191,15 @@ final class SupabaseAuthService: AuthServiceProtocol {
             return .noActiveSession
         }
 
-        if lowercased.contains("network")
+        if Self.isTransportError(error)
+            || lowercased.contains("network")
             || lowercased.contains("offline")
             || lowercased.contains("timed out")
-            || lowercased.contains("connection") {
+            || lowercased.contains("connection")
+            || lowercased.contains("hostname")
+            || lowercased.contains("host name")
+            || lowercased.contains("server could not be found")
+            || lowercased.contains("could not connect to the server") {
             return .transport(message.isEmpty ? "Network request failed." : message)
         }
 
@@ -191,6 +207,45 @@ final class SupabaseAuthService: AuthServiceProtocol {
             return .unknown("Authentication failed.")
         }
         return .unknown(message)
+    }
+
+    private static func isTransportError(_ error: Error) -> Bool {
+        if let urlError = error as? URLError {
+            return Self.isTransportCode(urlError.code)
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return Self.isTransportCode(URLError.Code(rawValue: nsError.code))
+        }
+
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return Self.isTransportError(underlying)
+        }
+
+        return false
+    }
+
+    private static func isTransportCode(_ code: URLError.Code) -> Bool {
+        switch code {
+        case .badServerResponse,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .dataNotAllowed,
+             .dnsLookupFailed,
+             .internationalRoamingOff,
+             .networkConnectionLost,
+             .notConnectedToInternet,
+             .secureConnectionFailed,
+             .serverCertificateHasBadDate,
+             .serverCertificateHasUnknownRoot,
+             .serverCertificateNotYetValid,
+             .serverCertificateUntrusted,
+             .timedOut:
+            return true
+        default:
+            return false
+        }
     }
 
     private static func isRecoveryURL(_ url: URL) -> Bool {

--- a/TinniTrack/Shared/App/SessionStore.swift
+++ b/TinniTrack/Shared/App/SessionStore.swift
@@ -33,6 +33,7 @@ final class SessionStore: ObservableObject {
         enum Banner: Equatable {
             case info(String)
             case error(String)
+            case titledError(title: String, message: String)
 
             var title: String {
                 switch self {
@@ -40,6 +41,8 @@ final class SessionStore: ObservableObject {
                     return "Info"
                 case .error:
                     return "Error"
+                case .titledError(let title, _):
+                    return title
                 }
             }
 
@@ -48,6 +51,8 @@ final class SessionStore: ObservableObject {
                 case .info(let message):
                     return message
                 case .error(let message):
+                    return message
+                case .titledError(_, let message):
                     return message
                 }
             }
@@ -133,7 +138,7 @@ final class SessionStore: ObservableObject {
             hasStarted = true
             startAuthStateListener()
             state = .bootstrapping
-            await refreshRoute(preserveRouteOnFailure: false)
+            await refreshRoute(preserveRouteOnFailure: false, showErrorBanner: false)
         }
     }
 
@@ -144,7 +149,7 @@ final class SessionStore: ObservableObject {
             do {
                 try await authService.signIn(email: normalizedEmail, password: password)
                 clearPendingEmailVerification()
-                await refreshRoute(preserveRouteOnFailure: true)
+                await refreshRoute(preserveRouteOnFailure: true, showErrorBanner: true)
             } catch let authError as AuthServiceError {
                 if case .emailNotConfirmed = authError {
                     setPendingEmailVerification(normalizedEmail)
@@ -185,7 +190,7 @@ final class SessionStore: ObservableObject {
                     state.banner = .info("Check your email to verify your account.")
                 }
 
-                await refreshRoute(preserveRouteOnFailure: true)
+                await refreshRoute(preserveRouteOnFailure: true, showErrorBanner: true)
             } catch {
                 setErrorBanner(from: error)
             }
@@ -200,7 +205,7 @@ final class SessionStore: ObservableObject {
                     lastName: lastName,
                     dateOfBirth: dateOfBirth
                 )
-                await refreshRoute(preserveRouteOnFailure: true)
+                await refreshRoute(preserveRouteOnFailure: true, showErrorBanner: true)
             } catch {
                 setErrorBanner(from: error)
             }
@@ -244,7 +249,7 @@ final class SessionStore: ObservableObject {
                 case .none:
                     break
                 }
-                await refreshRoute(preserveRouteOnFailure: true)
+                await refreshRoute(preserveRouteOnFailure: true, showErrorBanner: true)
             } catch {
                 setErrorBanner(from: error)
             }
@@ -257,7 +262,7 @@ final class SessionStore: ObservableObject {
                 try await authService.updatePassword(newPassword: newPassword)
                 state.passwordResetPresented = false
                 state.banner = .info("Password updated.")
-                await refreshRoute(preserveRouteOnFailure: true)
+                await refreshRoute(preserveRouteOnFailure: true, showErrorBanner: true)
             } catch {
                 setErrorBanner(from: error)
             }
@@ -291,7 +296,7 @@ final class SessionStore: ObservableObject {
 
     func checkEmailVerificationStatus() async {
         await execute(activity: .checkingVerificationStatus) { [self] in
-            await refreshRoute(preserveRouteOnFailure: true)
+            await refreshRoute(preserveRouteOnFailure: true, showErrorBanner: true)
             if case .awaitingEmailVerification = state.route, state.banner == nil {
                 state.banner = .info("Still waiting for verification. Open the email link on this device.")
             }
@@ -309,7 +314,7 @@ final class SessionStore: ObservableObject {
             guard let self else { return }
             for await _ in self.authService.authStateStream() {
                 await self.engine.run { [self] in
-                    await self.refreshRoute(preserveRouteOnFailure: true)
+                    await self.refreshRoute(preserveRouteOnFailure: true, showErrorBanner: false)
                 }
             }
         }
@@ -330,7 +335,7 @@ final class SessionStore: ObservableObject {
         }
     }
 
-    private func refreshRoute(preserveRouteOnFailure: Bool) async {
+    private func refreshRoute(preserveRouteOnFailure: Bool, showErrorBanner: Bool) async {
         let previousRoute = state.route
 
         do {
@@ -349,7 +354,9 @@ final class SessionStore: ObservableObject {
                 state.route = .needsOnboarding(profile: latestProfile)
             }
         } catch {
-            setErrorBanner(from: error)
+            if showErrorBanner {
+                setErrorBanner(from: error)
+            }
             if preserveRouteOnFailure {
                 state.route = previousRoute
             } else {
@@ -385,7 +392,12 @@ final class SessionStore: ObservableObject {
         if let authError = error as? AuthServiceError,
            let description = authError.errorDescription,
            !description.isEmpty {
-            state.banner = .error(description)
+            switch authError {
+            case .transport:
+                state.banner = .titledError(title: "Unable to Connect", message: description)
+            case .emailNotConfirmed, .noActiveSession, .callbackFailed, .unknown:
+                state.banner = .error(description)
+            }
         } else {
             state.banner = .error(error.localizedDescription)
         }

--- a/TinniTrackTests/SessionStoreTests.swift
+++ b/TinniTrackTests/SessionStoreTests.swift
@@ -17,6 +17,22 @@ struct SessionStoreTests {
     }
 
     @Test
+    func startSuppressesInitialBackendFailureBanner() async {
+        let auth = MockAuthService(
+            currentSession: nil,
+            currentSessionError: AuthServiceError.transport("A server with the specified hostname could not be found.")
+        )
+        let profile = MockProfileService(profile: nil)
+        let pending = MockEmailVerificationPendingStore(pending: nil)
+        let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
+
+        await store.start()
+
+        #expect(store.state.route == .unauthenticated)
+        #expect(store.state.banner == nil)
+    }
+
+    @Test
     func startMovesToAwaitingVerificationWhenPendingEmailExists() async {
         let auth = MockAuthService(currentSession: nil)
         let profile = MockProfileService(profile: nil)
@@ -214,8 +230,9 @@ struct SessionStoreTests {
             #expect(Bool(false), "Expected existing .ready route to be preserved")
         }
 
-        if case .error(let message)? = store.state.banner {
-            #expect(message == "Network unavailable")
+        if case .titledError(let title, let message)? = store.state.banner {
+            #expect(title == "Unable to Connect")
+            #expect(message == AuthServiceError.serviceUnavailableMessage)
         } else {
             #expect(Bool(false), "Expected error banner after refresh failure")
         }
@@ -240,10 +257,33 @@ struct SessionStoreTests {
         await store.checkEmailVerificationStatus()
 
         #expect(store.state.route == .awaitingEmailVerification(email: "pending@example.com"))
-        if case .error(let message)? = store.state.banner {
-            #expect(message == "Network unavailable")
+        if case .titledError(let title, let message)? = store.state.banner {
+            #expect(title == "Unable to Connect")
+            #expect(message == AuthServiceError.serviceUnavailableMessage)
         } else {
             #expect(Bool(false), "Expected refresh error banner to remain visible")
+        }
+    }
+
+    @Test
+    func signInTransportFailureShowsUnableToConnectMessage() async {
+        let auth = MockAuthService(
+            currentSession: nil,
+            signInError: AuthServiceError.transport("A server with the specified hostname could not be found.")
+        )
+        let profile = MockProfileService(profile: nil)
+        let pending = MockEmailVerificationPendingStore(pending: nil)
+        let store = SessionStore(authService: auth, profileService: profile, emailVerificationPendingStore: pending)
+
+        await store.start()
+        await store.signIn(email: "person@example.com", password: "password123")
+
+        #expect(store.state.route == .unauthenticated)
+        if case .titledError(let title, let message)? = store.state.banner {
+            #expect(title == "Unable to Connect")
+            #expect(message == AuthServiceError.serviceUnavailableMessage)
+        } else {
+            #expect(Bool(false), "Expected unable-to-connect banner after sign-in transport failure")
         }
     }
 


### PR DESCRIPTION
**Description**
This PR improves how TinniTrack handles backend/auth connectivity failures, especially when Supabase is unavailable after the project has been dormant.

Previously, the app surfaced a raw system error on launch, such as “A server with the specified hostname could not be found.” That message was shown before the user had taken any action and was not useful.

This change suppresses passive startup/auth-listener backend failures and only presents a user-facing error when the user performs an auth-related action.

**Changes**
- Suppresses backend connectivity alerts during initial app launch/session refresh.
- Preserves explicit error handling for user actions like login, signup, password reset, and verification refresh.
- Maps Supabase/URLSession transport failures to:
  - Title: `Unable to Connect`
  - Message: `We couldn't reach TinniTrack's servers. Please check your connection or try again later.`
- Adds regression coverage for startup suppression and login-time transport errors.

**Testing**
- Passed `TinniTrackTests/SessionStoreTests`
- Passed full `TinniTrackTests` target: 53 tests passed