### PR TITLE
Change research kit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "Frameworks/ResearchKit"]
+	path = Frameworks/ResearchKit
+	url = https://github.com/ResearchKit/ResearchKit.git
+	branch = stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-- This is an iOS research app for tinnitus study workflows, built with SwiftUI, HealthKit, Apple ResearchKit embedded dynamic frameworks, and Supabase.
+- This is an iOS research app for tinnitus study workflows, built with SwiftUI, HealthKit, Apple ResearchKit framework, and Supabase.
 
 - Preserve the feature-first structure:
   - `TinniTrack/Features/` for product flows, UI, and flow view models.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-- This is an iOS research app for tinnitus study workflows, built with SwiftUI, HealthKit, a StanfordBDHG ResearchKit SwiftPM fork, and Supabase.
+- This is an iOS research app for tinnitus study workflows, built with SwiftUI, HealthKit, Apple ResearchKit embedded dynamic frameworks, and Supabase.
 
 - Preserve the feature-first structure:
   - `TinniTrack/Features/` for product flows, UI, and flow view models.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ The app is an iOS research-app prototype for tinnitus study workflows. It curren
 *   Baseline hearing thresholds (via HealthKit Audiograms).
 *   Longitudinal Tinnitus Loudness-Match (LM) and Pitch-Match (PM) measurements.
 
+## Local Setup
+
+This repo uses Apple ResearchKit as a git submodule at `Frameworks/ResearchKit`.
+
+For a fresh clone, include submodules:
+
+```sh
+git clone --recurse-submodules <repo-url>
+cd Tinnitus-Capstone
+git -C Frameworks/ResearchKit lfs pull --include='LFS-Files/**' --exclude=''
+```
+
+If you already cloned the repo without submodules:
+
+```sh
+git submodule update --init --recursive
+git -C Frameworks/ResearchKit lfs pull --include='LFS-Files/**' --exclude=''
+```
+
+Then drag `Frameworks/ResearchKit/ResearchKit.xcodeproj` into `TinniTrack.xcodeproj` in Xcode and embed `ResearchKit.framework`, `ResearchKitUI.framework`, and `ResearchKitActiveTask.framework` in the app target.
+
 ## 2. Why we’re building it
 *   **Objectivity:** Tinnitus is subjective; standardized calibration (dB SL/HL) allows for inter-subject and longitudinal comparison.
 *   **Hardware Consistency:** Apple devices (specifically AirPods Pro) provide known acoustic profiles, enabling clinical-grade accuracy outside a sound booth.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Users complete loudness-matching tasks at specific times of day.
 *   **UI/UX:** SwiftUI
 *   **Frameworks:**
     *   **HealthKit:** For audiogram retrieval.
-    *   **ResearchKit (StanfordBDHG Fork):** We use [StanfordBDHG’s SPM fork of Apple ResearchKit](https://github.com/StanfordBDHG/ResearchKit), resolved through SwiftPM and pinned in `Package.resolved`.
+    *   **ResearchKit:** We use Apple ResearchKit as embedded dynamic frameworks via `ResearchKit.xcodeproj`.
 
 ### ResearchKit Direction
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Users complete loudness-matching tasks at specific times of day.
 *   **UI/UX:** SwiftUI
 *   **Frameworks:**
     *   **HealthKit:** For audiogram retrieval.
-    *   **ResearchKit:** We use Apple ResearchKit as embedded dynamic frameworks via `ResearchKit.xcodeproj`.
+    *   **ResearchKit:** We use Apple ResearchKit frameworks via `ResearchKit.xcodeproj`.
 
 ### ResearchKit Direction
 

--- a/TinniTrack.xcodeproj/project.pbxproj
+++ b/TinniTrack.xcodeproj/project.pbxproj
@@ -13,10 +13,6 @@
 		E1CBE51A2EE26FCC005AB9B0 /* Realtime in Frameworks */ = {isa = PBXBuildFile; productRef = E1CBE5192EE26FCC005AB9B0 /* Realtime */; };
 		E1CBE51C2EE26FCC005AB9B0 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = E1CBE51B2EE26FCC005AB9B0 /* Storage */; };
 		E1CBE51E2EE26FCC005AB9B0 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = E1CBE51D2EE26FCC005AB9B0 /* Supabase */; };
-		E1EADEF92FD4E43E00F207B7 /* ResearchKit in Frameworks */ = {isa = PBXBuildFile; productRef = E1EADEF82FD4E43E00F207B7 /* ResearchKit */; };
-		E1EADEFB2FD4E43E00F207B7 /* ResearchKitActiveTask in Frameworks */ = {isa = PBXBuildFile; productRef = E1EADEFA2FD4E43E00F207B7 /* ResearchKitActiveTask */; };
-		E1EADEFD2FD4E43E00F207B7 /* ResearchKitSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = E1EADEFC2FD4E43E00F207B7 /* ResearchKitSwiftUI */; };
-		E1EADEFF2FD4E43E00F207B7 /* ResearchKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = E1EADEFE2FD4E43E00F207B7 /* ResearchKitUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,12 +61,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E1EADEFF2FD4E43E00F207B7 /* ResearchKitUI in Frameworks */,
-				E1EADEFD2FD4E43E00F207B7 /* ResearchKitSwiftUI in Frameworks */,
 				E1CBE5182EE26FCC005AB9B0 /* PostgREST in Frameworks */,
-				E1EADEFB2FD4E43E00F207B7 /* ResearchKitActiveTask in Frameworks */,
 				E1CBE5162EE26FCC005AB9B0 /* Functions in Frameworks */,
-				E1EADEF92FD4E43E00F207B7 /* ResearchKit in Frameworks */,
 				E1CBE51E2EE26FCC005AB9B0 /* Supabase in Frameworks */,
 				E1CBE5142EE26FCC005AB9B0 /* Auth in Frameworks */,
 				E1CBE51C2EE26FCC005AB9B0 /* Storage in Frameworks */,
@@ -141,10 +133,6 @@
 				E1CBE5192EE26FCC005AB9B0 /* Realtime */,
 				E1CBE51B2EE26FCC005AB9B0 /* Storage */,
 				E1CBE51D2EE26FCC005AB9B0 /* Supabase */,
-				E1EADEF82FD4E43E00F207B7 /* ResearchKit */,
-				E1EADEFA2FD4E43E00F207B7 /* ResearchKitActiveTask */,
-				E1EADEFC2FD4E43E00F207B7 /* ResearchKitSwiftUI */,
-				E1EADEFE2FD4E43E00F207B7 /* ResearchKitUI */,
 			);
 			productName = TinniTrack;
 			productReference = E1CBE3FC2EE269DD005AB9B0 /* TinniTrack.app */;
@@ -230,7 +218,6 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				E1CBE5122EE26FCC005AB9B0 /* XCRemoteSwiftPackageReference "supabase-swift" */,
-				E1EADEF72FD4E43E00F207B7 /* XCRemoteSwiftPackageReference "ResearchKit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E1CBE3FD2EE269DD005AB9B0 /* Products */;
@@ -611,14 +598,6 @@
 				minimumVersion = 2.5.1;
 			};
 		};
-		E1EADEF72FD4E43E00F207B7 /* XCRemoteSwiftPackageReference "ResearchKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordBDHG/ResearchKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.4;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -651,26 +630,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E1CBE5122EE26FCC005AB9B0 /* XCRemoteSwiftPackageReference "supabase-swift" */;
 			productName = Supabase;
-		};
-		E1EADEF82FD4E43E00F207B7 /* ResearchKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E1EADEF72FD4E43E00F207B7 /* XCRemoteSwiftPackageReference "ResearchKit" */;
-			productName = ResearchKit;
-		};
-		E1EADEFA2FD4E43E00F207B7 /* ResearchKitActiveTask */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E1EADEF72FD4E43E00F207B7 /* XCRemoteSwiftPackageReference "ResearchKit" */;
-			productName = ResearchKitActiveTask;
-		};
-		E1EADEFC2FD4E43E00F207B7 /* ResearchKitSwiftUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E1EADEF72FD4E43E00F207B7 /* XCRemoteSwiftPackageReference "ResearchKit" */;
-			productName = ResearchKitSwiftUI;
-		};
-		E1EADEFE2FD4E43E00F207B7 /* ResearchKitUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E1EADEF72FD4E43E00F207B7 /* XCRemoteSwiftPackageReference "ResearchKit" */;
-			productName = ResearchKitUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TinniTrack.xcodeproj/project.pbxproj
+++ b/TinniTrack.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E1C796B22FE887F300B8979E /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1C796AA2FE887B300B8979E /* ResearchKit.framework */; };
+		E1C796B32FE887F300B8979E /* ResearchKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1C796AA2FE887B300B8979E /* ResearchKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E1C796B52FE888B900B8979E /* ResearchKitActiveTask.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1C796B02FE887B300B8979E /* ResearchKitActiveTask.framework */; };
+		E1C796B62FE888B900B8979E /* ResearchKitActiveTask.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1C796B02FE887B300B8979E /* ResearchKitActiveTask.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E1C796B72FE888B900B8979E /* ResearchKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1C796AE2FE887B300B8979E /* ResearchKitUI.framework */; };
+		E1C796B82FE888B900B8979E /* ResearchKitUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1C796AE2FE887B300B8979E /* ResearchKitUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E1CBE5142EE26FCC005AB9B0 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = E1CBE5132EE26FCC005AB9B0 /* Auth */; };
 		E1CBE5162EE26FCC005AB9B0 /* Functions in Frameworks */ = {isa = PBXBuildFile; productRef = E1CBE5152EE26FCC005AB9B0 /* Functions */; };
 		E1CBE5182EE26FCC005AB9B0 /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = E1CBE5172EE26FCC005AB9B0 /* PostgREST */; };
@@ -16,6 +22,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		E1C796A92FE887B300B8979E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E1C7968F2FE887B200B8979E /* ResearchKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = B183A5951A8535D100C76870;
+			remoteInfo = ResearchKit;
+		};
+		E1C796AD2FE887B300B8979E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E1C7968F2FE887B200B8979E /* ResearchKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CA1C7A5A288B0C68004DAB3A;
+			remoteInfo = ResearchKitUI;
+		};
+		E1C796AF2FE887B300B8979E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E1C7968F2FE887B200B8979E /* ResearchKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CAD08967289DD747007B2A98;
+			remoteInfo = ResearchKitActiveTask;
+		};
 		E1CBE40A2EE269DE005AB9B0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E1CBE3F42EE269DD005AB9B0 /* Project object */;
@@ -32,7 +59,24 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		E1C796B42FE887F300B8979E /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				E1C796B82FE888B900B8979E /* ResearchKitUI.framework in Embed Frameworks */,
+				E1C796B32FE887F300B8979E /* ResearchKit.framework in Embed Frameworks */,
+				E1C796B62FE888B900B8979E /* ResearchKitActiveTask.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		E1C7968F2FE887B200B8979E /* ResearchKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchKit.xcodeproj; path = Frameworks/ResearchKit/ResearchKit.xcodeproj; sourceTree = "<group>"; };
 		E1CBE3FC2EE269DD005AB9B0 /* TinniTrack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TinniTrack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1CBE4092EE269DE005AB9B0 /* TinniTrackTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TinniTrackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1CBE4132EE269DE005AB9B0 /* TinniTrackUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TinniTrackUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -61,12 +105,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1C796B72FE888B900B8979E /* ResearchKitUI.framework in Frameworks */,
 				E1CBE5182EE26FCC005AB9B0 /* PostgREST in Frameworks */,
 				E1CBE5162EE26FCC005AB9B0 /* Functions in Frameworks */,
 				E1CBE51E2EE26FCC005AB9B0 /* Supabase in Frameworks */,
 				E1CBE5142EE26FCC005AB9B0 /* Auth in Frameworks */,
 				E1CBE51C2EE26FCC005AB9B0 /* Storage in Frameworks */,
+				E1C796B22FE887F300B8979E /* ResearchKit.framework in Frameworks */,
 				E1CBE51A2EE26FCC005AB9B0 /* Realtime in Frameworks */,
+				E1C796B52FE888B900B8979E /* ResearchKitActiveTask.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,6 +134,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E1C796902FE887B200B8979E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E1C796AA2FE887B300B8979E /* ResearchKit.framework */,
+				E1C796AE2FE887B300B8979E /* ResearchKitUI.framework */,
+				E1C796B02FE887B300B8979E /* ResearchKitActiveTask.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E1C796B12FE887F300B8979E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		E1CBE3F32EE269DD005AB9B0 = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +158,8 @@
 				E1CBE40C2EE269DE005AB9B0 /* TinniTrackTests */,
 				E1CBE4162EE269DE005AB9B0 /* TinniTrackUITests */,
 				E1CBE3FD2EE269DD005AB9B0 /* Products */,
+				E1C7968F2FE887B200B8979E /* ResearchKit.xcodeproj */,
+				E1C796B12FE887F300B8979E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -117,6 +183,7 @@
 				E1CBE3F82EE269DD005AB9B0 /* Sources */,
 				E1CBE3F92EE269DD005AB9B0 /* Frameworks */,
 				E1CBE3FA2EE269DD005AB9B0 /* Resources */,
+				E1C796B42FE887F300B8979E /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,6 +289,12 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E1CBE3FD2EE269DD005AB9B0 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = E1C796902FE887B200B8979E /* Products */;
+					ProjectRef = E1C7968F2FE887B200B8979E /* ResearchKit.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				E1CBE3FB2EE269DD005AB9B0 /* TinniTrack */,
@@ -230,6 +303,30 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		E1C796AA2FE887B300B8979E /* ResearchKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ResearchKit.framework;
+			remoteRef = E1C796A92FE887B300B8979E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E1C796AE2FE887B300B8979E /* ResearchKitUI.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ResearchKitUI.framework;
+			remoteRef = E1C796AD2FE887B300B8979E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E1C796B02FE887B300B8979E /* ResearchKitActiveTask.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ResearchKitActiveTask.framework;
+			remoteRef = E1C796AF2FE887B300B8979E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E1CBE3FA2EE269DD005AB9B0 /* Resources */ = {

--- a/TinniTrack.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinniTrack.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "fe99e8d0c4d6cfe7fa8baaeee79c015938b41a5065032bdf847a5cd0e6ce3a5b",
+  "originHash" : "497b223336ae156cc4edd8c12c3d176b975452a34540e6bdf0a3cf91a248bc9c",
   "pins" : [
-    {
-      "identity" : "researchkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordBDHG/ResearchKit",
-      "state" : {
-        "revision" : "d1d523e9e738b7ad9c97ca6101aada1c041ea9da",
-        "version" : "3.1.4"
-      }
-    },
     {
       "identity" : "supabase-swift",
       "kind" : "remoteSourceControl",

--- a/docs/adr/0001-researchkit-and-measurement-architecture.md
+++ b/docs/adr/0001-researchkit-and-measurement-architecture.md
@@ -10,7 +10,7 @@ Accepted for architecture readiness.
 
 TinniTrack needs to continue toward ResearchKit-backed hearing-study workflows without pretending the current Study No. 1 loudness-match prototype is scientifically valid. The app also needs a lower deployment target than the Xcode-created iOS 26.1 default.
 
-The StanfordBDHG ResearchKit package is already available through SwiftPM and is resolved to `3.1.4`. Its package manifest declares iOS 17+, so TinniTrack can target iOS 18.1.
+ResearchKit is integrated through Apple's embedded framework project flow by adding `ResearchKit.xcodeproj` to the app project and embedding the `ResearchKit`, `ResearchKitUI`, and `ResearchKitActiveTask` dynamic frameworks. TinniTrack targets iOS 18.1.
 
 ## Decision
 


### PR DESCRIPTION
## Summary

Switch ResearchKit integration from the StanfordBDHG SwiftPM fork to Apple’s original ResearchKit embedded framework setup.

## Rationale

We previously used the StanfordBDHG ResearchKit fork because it provided convenient Swift Package Manager integration. However, that fork was not up to date with important changes in ResearchKit’s audiometry modules. Since this app depends on ResearchKit’s audiometry surfaces for future hearing-study workflows, I decided the more current Apple implementation was more important than the convenience of the Stanford fork’s SPM packaging.

## Changes

- Removed the StanfordBDHG ResearchKit SwiftPM package from the Xcode project and `Package.resolved`.
- Added Apple ResearchKit as a git submodule at `Frameworks/ResearchKit`.
- Added `ResearchKit.xcodeproj` to the app project.
- Linked and embedded the required dynamic frameworks:
  - `ResearchKit.framework`
  - `ResearchKitUI.framework`
  - `ResearchKitActiveTask.framework`
- Updated README setup instructions for cloning with submodules and pulling ResearchKit LFS assets.
- Updated project docs to refer to Apple ResearchKit embedded frameworks instead of the StanfordBDHG SwiftPM fork.

## Validation

- Confirmed the app target links and embeds all three ResearchKit frameworks with code signing.
- Confirmed SwiftPM no longer resolves Stanford ResearchKit.
- Built the app successfully:

```sh
xcodebuild -project TinniTrack.xcodeproj \
  -scheme TinniTrack \
  -destination 'id=57FA0EF4-700A-4EBA-A5B1-E0641B6FC166' \
  -configuration Debug \
  build